### PR TITLE
Pet 41 feat : JWT 인증 필터 추가 및 JWT 인증, 인증 타입 분리, 이메일 추출 서비스 추가

### DIFF
--- a/Api-Module/src/main/java/com/petmory/apimodule/ApiModuleApplication.java
+++ b/Api-Module/src/main/java/com/petmory/apimodule/ApiModuleApplication.java
@@ -3,9 +3,10 @@ package com.petmory.apimodule;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class })
 @ComponentScan(basePackages = {"com.petmory"})
 @EntityScan(basePackages = {"com.petmory"})
 public class ApiModuleApplication {

--- a/Auth-Module/auth-adaptor/src/main/java/com/petmory/authmodule/config/security/JWTAuthenticationToken.java
+++ b/Auth-Module/auth-adaptor/src/main/java/com/petmory/authmodule/config/security/JWTAuthenticationToken.java
@@ -1,0 +1,23 @@
+package com.petmory.authmodule.config.security;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+
+public class JWTAuthenticationToken extends AbstractAuthenticationToken {
+    private String email;
+    public JWTAuthenticationToken(String email) {
+        super(null);
+        this.email=email;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return null;
+    }
+}

--- a/Auth-Module/auth-adaptor/src/main/java/com/petmory/authmodule/config/security/SecurityConfig.java
+++ b/Auth-Module/auth-adaptor/src/main/java/com/petmory/authmodule/config/security/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.petmory.authmodule.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain chain(HttpSecurity http) throws Exception {
+        http.cors().disable();
+        http.addFilterBefore(SecurityHandler.getJWTAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        http.csrf().disable();
+
+        http.authorizeHttpRequests( request ->{
+            request.anyRequest().permitAll();
+        });
+
+        http.formLogin().disable();
+        http.httpBasic().disable();
+        http.logout().disable();
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        return http.build();
+    }
+
+}

--- a/Auth-Module/auth-adaptor/src/main/java/com/petmory/authmodule/config/security/SecurityHandler.java
+++ b/Auth-Module/auth-adaptor/src/main/java/com/petmory/authmodule/config/security/SecurityHandler.java
@@ -1,0 +1,17 @@
+package com.petmory.authmodule.config.security;
+
+import com.petmory.authmodule.config.security.filter.JWTAuthenticationFilter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityHandler {
+    private static JWTAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityHandler(JWTAuthenticationFilter jwtAuthenticationFilter) {
+        SecurityHandler.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    public static JWTAuthenticationFilter getJWTAuthenticationFilter(){
+        return jwtAuthenticationFilter;
+    }
+}

--- a/Auth-Module/auth-adaptor/src/main/java/com/petmory/authmodule/config/security/filter/JWTAuthenticationFilter.java
+++ b/Auth-Module/auth-adaptor/src/main/java/com/petmory/authmodule/config/security/filter/JWTAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package com.petmory.authmodule.config.security.filter;
+
+import com.petmory.authmodule.application.common.consts.AuthConsts;
+import com.petmory.authmodule.application.common.consts.IgnoredPathConsts;
+import com.petmory.authmodule.application.common.exception.InvalidAuthorizationTypeException;
+import com.petmory.authmodule.application.port.in.JWTExtractEmailUseCase;
+import com.petmory.authmodule.application.port.in.JWTExtractTokenUseCase;
+import com.petmory.authmodule.application.port.in.JWTVerifyUseCase;
+import com.petmory.authmodule.config.security.JWTAuthenticationToken;
+import com.petmory.commonmodule.exception.Error;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class JWTAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JWTVerifyUseCase jwtVerifyUseCase;
+    private final JWTExtractEmailUseCase jwtExtractEmailUseCase;
+    private final JWTExtractTokenUseCase jwtExtractTokenUseCase;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if(!isIgnoredPath(request)){
+            final String tokenHeaderValue = getTokenFromHeader(request);
+            final String accessToken = jwtExtractTokenUseCase.extractToken(tokenHeaderValue);
+            jwtVerifyUseCase.validateToken(accessToken);
+            final String email = jwtExtractEmailUseCase.extractEmail(accessToken);
+            initAuthentication(new JWTAuthenticationToken(email));
+        }
+        filterChain.doFilter(request, response);
+    }
+
+
+    private String getTokenFromHeader(HttpServletRequest request){
+        String header = request.getHeader(AuthConsts.AUTHORIZATION);
+        if(StringUtils.hasText(header)) return header;
+        throw new InvalidAuthorizationTypeException(Error.EMPTY_AUTHORIZATION_HEADER);
+    }
+
+    private Boolean isIgnoredPath(HttpServletRequest request){
+        final Set<String> ignoredPathURI = IgnoredPathConsts.getIgnoredPath().keySet();
+        return ignoredPathURI.stream()
+            .anyMatch(ignoredPath -> isMatchingPath(request, ignoredPath)&&isMatchingMethod(request, ignoredPath));
+    }
+
+    private Boolean isMatchingPath(HttpServletRequest request, String ignoredPathURI){
+        final AntPathMatcher antPathMatcher = new AntPathMatcher();
+        return antPathMatcher.matchStart(ignoredPathURI, request.getRequestURI());
+    }
+
+    private Boolean isMatchingMethod(HttpServletRequest request, String ignoredPathURI){
+        return IgnoredPathConsts.getIgnoredPath().get(ignoredPathURI).matches(request.getMethod());
+    }
+
+    private void initAuthentication(final Authentication authentication){
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+}

--- a/Auth-Module/auth-application/build.gradle
+++ b/Auth-Module/auth-application/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(":Auth-Module:JWT")
+}

--- a/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/common/config/OAuthConfig.java
+++ b/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/common/config/OAuthConfig.java
@@ -1,4 +1,4 @@
-package com.petmory.authmodule.application.config;
+package com.petmory.authmodule.application.common.config;
 
 import com.petmory.authmodule.application.port.out.observer.subject.AbstractOAuthSubject;
 import com.petmory.commonmodule.utill.ApplicationContextUtils;

--- a/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/common/consts/AuthConsts.java
+++ b/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/common/consts/AuthConsts.java
@@ -1,0 +1,10 @@
+package com.petmory.authmodule.application.common.consts;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthConsts {
+    public static final String AUTHENTICATION_TYPE= "Bearer";
+    public static final String AUTHORIZATION = "Authorization";
+}

--- a/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/common/consts/IgnoredPathConsts.java
+++ b/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/common/consts/IgnoredPathConsts.java
@@ -1,0 +1,20 @@
+package com.petmory.authmodule.application.common.consts;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpMethod;
+
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IgnoredPathConsts {
+
+    @Getter
+    private static Map<String, HttpMethod> ignoredPath = Map.of(
+        "/oauth/**", HttpMethod.GET,
+        "/jwt", HttpMethod.GET,
+        "/actuator/**", HttpMethod.GET
+    );
+
+}

--- a/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/common/exception/AuthException.java
+++ b/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/common/exception/AuthException.java
@@ -1,0 +1,10 @@
+package com.petmory.authmodule.application.common.exception;
+
+import com.petmory.commonmodule.exception.BusinessException;
+import com.petmory.commonmodule.exception.Error;
+
+public class AuthException extends BusinessException {
+    public AuthException(Error error) {
+        super(error);
+    }
+}

--- a/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/common/exception/InvalidAuthorizationTypeException.java
+++ b/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/common/exception/InvalidAuthorizationTypeException.java
@@ -1,0 +1,9 @@
+package com.petmory.authmodule.application.common.exception;
+
+import com.petmory.commonmodule.exception.Error;
+
+public class InvalidAuthorizationTypeException extends AuthException {
+    public InvalidAuthorizationTypeException(Error error) {
+        super(error);
+    }
+}

--- a/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/port/in/JWTExtractEmailUseCase.java
+++ b/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/port/in/JWTExtractEmailUseCase.java
@@ -1,0 +1,5 @@
+package com.petmory.authmodule.application.port.in;
+
+public interface JWTExtractEmailUseCase {
+    String extractEmail(final String token);
+}

--- a/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/port/in/JWTExtractTokenUseCase.java
+++ b/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/port/in/JWTExtractTokenUseCase.java
@@ -1,0 +1,5 @@
+package com.petmory.authmodule.application.port.in;
+
+public interface JWTExtractTokenUseCase {
+    String extractToken(final String tokenHeader);
+}

--- a/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/port/in/JWTVerifyUseCase.java
+++ b/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/port/in/JWTVerifyUseCase.java
@@ -1,0 +1,5 @@
+package com.petmory.authmodule.application.port.in;
+
+public interface JWTVerifyUseCase {
+    void validateToken(final String token);
+}

--- a/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/service/JWTExtractEmailService.java
+++ b/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/service/JWTExtractEmailService.java
@@ -1,0 +1,17 @@
+package com.petmory.authmodule.application.service;
+
+import com.petmory.authmodule.application.port.in.JWTExtractEmailUseCase;
+import com.petmory.jwt.JWTProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JWTExtractEmailService implements JWTExtractEmailUseCase {
+    private final JWTProvider jwtProvider;
+
+    @Override
+    public String extractEmail(final String token){
+        return jwtProvider.extractEmailFromAccessToken(token);
+    }
+}

--- a/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/service/JWTExtractTokenService.java
+++ b/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/service/JWTExtractTokenService.java
@@ -1,0 +1,23 @@
+package com.petmory.authmodule.application.service;
+
+import com.petmory.authmodule.application.common.consts.AuthConsts;
+import com.petmory.authmodule.application.port.in.JWTExtractTokenUseCase;
+import com.petmory.commonmodule.exception.Error;
+import com.petmory.authmodule.application.common.exception.InvalidAuthorizationTypeException;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Service
+public class JWTExtractTokenService implements JWTExtractTokenUseCase {
+    @Override
+    public String extractToken(final String tokenHeader) {
+        final String[] splitToken = tokenHeader.split(" ");
+        final String authorizationType = splitToken[0];
+        final String accessToken = splitToken[1];
+        if(!Objects.equals(authorizationType, AuthConsts.AUTHENTICATION_TYPE)){
+            throw new InvalidAuthorizationTypeException(Error.INVALID_AUTHORIZATION_TYPE);
+        }
+        return accessToken;
+    }
+}

--- a/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/service/JWTVerifyService.java
+++ b/Auth-Module/auth-application/src/main/java/com/petmory/authmodule/application/service/JWTVerifyService.java
@@ -1,0 +1,17 @@
+package com.petmory.authmodule.application.service;
+
+import com.petmory.authmodule.application.port.in.JWTVerifyUseCase;
+import com.petmory.jwt.JWTProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JWTVerifyService implements JWTVerifyUseCase {
+    private final JWTProvider jwtProvider;
+
+    @Override
+    public void validateToken(final String token){
+        jwtProvider.validateToken(token);
+    }
+}

--- a/Auth-Module/build.gradle
+++ b/Auth-Module/build.gradle
@@ -1,5 +1,8 @@
 subprojects {
     dependencies {
         implementation project(":Common-Module")
+
+        // spring security
+        implementation "org.springframework.boot:spring-boot-starter-security"
     }
 }

--- a/Common-Module/src/main/java/com/petmory/commonmodule/exception/Error.java
+++ b/Common-Module/src/main/java/com/petmory/commonmodule/exception/Error.java
@@ -4,10 +4,12 @@ import lombok.Getter;
 
 @Getter
 public enum Error {
-    // JWT
+    // Security
     INVALID_TOKEN("유효하지 않은 토큰입니다.", 1001),
     EXPIRED_TOKEN("만료된 토큰입니다.", 1002),
-    NOT_EXIST_TOKEN("토큰이 존재하지 않습니다.", 1003)
+    NOT_EXIST_TOKEN("토큰이 존재하지 않습니다.", 1003),
+    INVALID_AUTHORIZATION_TYPE("유효하지 않은 Authorization Type 입니다.", 1004),
+    EMPTY_AUTHORIZATION_HEADER("Authorization Header가 비어있습니다.", 1005),
     ;
 
     private final String message;


### PR DESCRIPTION
## 작업사항
- (auth-adaptor) JWT 인증 필터 및 AuthenticationToken 추가
- (auth-adaptor) Security 설정 및 Security의존성관리 Handler 추가
- (auth-application) Auth Exception 추가
- (auth-application) 토큰 인증, 인증 타입 분리, 이메일 추출 서비스 추가
- (auth-application) OAuthConfig 클래스 위치 변경
- (JWT) access token에서 email 정보 추출 메소드 추가

## 변경로직
- refresh token에서 Email 정보 반환 메소드 이름 변경 (extractEmailFromToken -> extractEmailFromRefreshToken)

## 참고자료
- 내용을 적어주세요.



