### PR TITLE
PET-69 feat : 소셜 로그인 결과 사용자 email 기반 AccessToken, RefreshToken 생성 로직 추가

### DIFF
--- a/Auth-Module/JWT/src/main/java/com/pawith/jwt/JWTConsts.java
+++ b/Auth-Module/JWT/src/main/java/com/pawith/jwt/JWTConsts.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JWTConsts {
-    public static final String TOKEN_ISSUER = "petmory";
+    public static final String TOKEN_ISSUER = "pawith";
     public static final String EMAIL ="email";
     public static final String TOKEN_TYPE = "token_type";
 }

--- a/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/common/config/OAuthConfig.java
+++ b/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/common/config/OAuthConfig.java
@@ -1,6 +1,6 @@
 package com.pawith.authmodule.application.common.config;
 
-import com.pawith.authmodule.application.port.out.observer.subject.AbstractOAuthSubject;
+import com.pawith.authmodule.application.port.out.observer.subject.OAuthSubject;
 import com.pawith.commonmodule.utill.ApplicationContextUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -13,11 +13,11 @@ import org.springframework.web.client.RestTemplate;
 public class OAuthConfig {
 
     @Bean
-    public AbstractOAuthSubject abstractOAuthSubject(){
-        final AbstractOAuthSubject abstractOAuthSubject = new AbstractOAuthSubject();
+    public OAuthSubject abstractOAuthSubject(){
+        final OAuthSubject OAuthSubject = new OAuthSubject();
         final ApplicationContext applicationContext = ApplicationContextUtils.getApplicationContext();
-        abstractOAuthSubject.initStrategy(applicationContext);
-        return abstractOAuthSubject;
+        OAuthSubject.initStrategy(applicationContext);
+        return OAuthSubject;
     }
 
     @Bean

--- a/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/common/config/OAuthConfig.java
+++ b/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/common/config/OAuthConfig.java
@@ -16,7 +16,7 @@ public class OAuthConfig {
     public AbstractOAuthSubject abstractOAuthSubject(){
         final AbstractOAuthSubject abstractOAuthSubject = new AbstractOAuthSubject();
         final ApplicationContext applicationContext = ApplicationContextUtils.getApplicationContext();
-        abstractOAuthSubject.initObserver(applicationContext);
+        abstractOAuthSubject.initStrategy(applicationContext);
         return abstractOAuthSubject;
     }
 

--- a/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/common/consts/AuthConsts.java
+++ b/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/common/consts/AuthConsts.java
@@ -5,6 +5,6 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthConsts {
-    public static final String AUTHENTICATION_TYPE= "Bearer";
+    public static final String AUTHENTICATION_TYPE= "Bearer"+" ";
     public static final String AUTHORIZATION = "Authorization";
 }

--- a/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/dto/OAuthResponse.java
+++ b/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/dto/OAuthResponse.java
@@ -1,12 +1,13 @@
 package com.pawith.authmodule.application.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @RequiredArgsConstructor
-@ToString
+@Builder
 public class OAuthResponse {
-    private final String serverToken;
+    private final String accessToken;
+    private final String refreshToken;
 }

--- a/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/port/out/factory/DefaultOAuthFactory.java
+++ b/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/port/out/factory/DefaultOAuthFactory.java
@@ -3,17 +3,17 @@ package com.pawith.authmodule.application.port.out.factory;
 import com.pawith.authmodule.application.dto.OAuthRequest;
 import com.pawith.authmodule.application.dto.OAuthResponse;
 import com.pawith.authmodule.application.dto.Provider;
-import com.pawith.authmodule.application.port.out.observer.subject.AbstractOAuthSubject;
+import com.pawith.authmodule.application.port.out.observer.subject.OAuthSubject;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class DefaultOAuthFactory implements OAuthFactory {
-    private final AbstractOAuthSubject abstractOAuthSubject;
+    private final OAuthSubject OAuthSubject;
 
     @Override
     public OAuthResponse login(Provider provider, String accessToken) {
-        return abstractOAuthSubject.notifyObservers(new OAuthRequest(provider, accessToken));
+        return OAuthSubject.notifyObservers(new OAuthRequest(provider, accessToken));
     }
 }

--- a/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/port/out/observer/subject/AbstractOAuthSubject.java
+++ b/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/port/out/observer/subject/AbstractOAuthSubject.java
@@ -63,7 +63,7 @@ public final class AbstractOAuthSubject implements Subject<OAuthRequest, OAuthRe
         return AuthConsts.AUTHENTICATION_TYPE + generateTokenMethod.apply(includeClaimData);
     }
 
-    public void initObserver(ApplicationContext applicationContext){
+    public void initStrategy(ApplicationContext applicationContext){
         initOAuthObserver(applicationContext);
         initJWTProvider(applicationContext);
     }

--- a/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/port/out/observer/subject/AbstractOAuthSubject.java
+++ b/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/port/out/observer/subject/AbstractOAuthSubject.java
@@ -1,5 +1,6 @@
 package com.pawith.authmodule.application.port.out.observer.subject;
 
+import com.pawith.authmodule.application.common.consts.AuthConsts;
 import com.pawith.authmodule.application.dto.OAuthRequest;
 import com.pawith.authmodule.application.dto.OAuthResponse;
 import com.pawith.authmodule.application.dto.OAuthUserInfo;
@@ -7,17 +8,22 @@ import com.pawith.authmodule.application.port.out.observer.observer.AbstractOAut
 import com.pawith.commonmodule.observer.observer.Observer;
 import com.pawith.commonmodule.observer.subject.Status;
 import com.pawith.commonmodule.observer.subject.Subject;
-import lombok.NoArgsConstructor;
+import com.pawith.jwt.JWTProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 @Slf4j
-@NoArgsConstructor
 public final class AbstractOAuthSubject implements Subject<OAuthRequest, OAuthResponse> {
+
+    private static final String JWT_PROVIDER_BEAN_NAME = "JWTProvider";
+
     private final List<AbstractOAuthObserver> observerList = new ArrayList<>();
+
+    private JWTProvider jwtProvider;
 
     @Override
     public void registerObserver(Observer<? extends Status,?> o) {
@@ -32,7 +38,7 @@ public final class AbstractOAuthSubject implements Subject<OAuthRequest, OAuthRe
     @Override
     public OAuthResponse notifyObservers(OAuthRequest object) {
         final OAuthUserInfo oAuthUserInfo = attemptLogin(new OAuth(object.getProvider(), object.getAccessToken()));
-        return generateServerAccessTool(oAuthUserInfo);
+        return generateServerAuthenticationTokens(oAuthUserInfo);
     }
 
     private OAuthUserInfo attemptLogin(OAuth oAuth) {
@@ -44,13 +50,30 @@ public final class AbstractOAuthSubject implements Subject<OAuthRequest, OAuthRe
         throw new IllegalArgumentException("로그인 실패");
     }
 
-    private OAuthResponse generateServerAccessTool(OAuthUserInfo oAuthUserInfo) {
-        return new OAuthResponse(oAuthUserInfo.getEmail()+" "+oAuthUserInfo.getUsername());
+    private OAuthResponse generateServerAuthenticationTokens(OAuthUserInfo oAuthUserInfo) {
+        final String accessToken = attachAuthenticationType(jwtProvider::generateAccessToken, oAuthUserInfo.getEmail());
+        final String refreshToken = attachAuthenticationType(jwtProvider::generateRefreshToken, oAuthUserInfo.getEmail());
+        return OAuthResponse.builder()
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .build();
+    }
+
+    private <T> String attachAuthenticationType(Function<T, String> generateTokenMethod, T includeClaimData) {
+        return AuthConsts.AUTHENTICATION_TYPE + generateTokenMethod.apply(includeClaimData);
     }
 
     public void initObserver(ApplicationContext applicationContext){
+        initOAuthObserver(applicationContext);
+        initJWTProvider(applicationContext);
+    }
+
+    private void initOAuthObserver(ApplicationContext applicationContext) {
         applicationContext.getBeansOfType(AbstractOAuthObserver.class)
                 .values()
                 .forEach(this::registerObserver);
+    }
+    private void initJWTProvider(ApplicationContext applicationContext){
+        jwtProvider = applicationContext.getBean(JWT_PROVIDER_BEAN_NAME, JWTProvider.class);
     }
 }

--- a/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/port/out/observer/subject/OAuthSubject.java
+++ b/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/port/out/observer/subject/OAuthSubject.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.function.Function;
 
 @Slf4j
-public final class AbstractOAuthSubject implements Subject<OAuthRequest, OAuthResponse> {
+public final class OAuthSubject implements Subject<OAuthRequest, OAuthResponse> {
 
     private static final String JWT_PROVIDER_BEAN_NAME = "JWTProvider";
 


### PR DESCRIPTION
## 작업사항
- 소셜 로그인 결과 OAuthInfo 객체의 email 정보 기반 AccessToken, RefreshToken 생성 후 반환 로직 추가
- AbstractOAuthSubject의 JWTProvider의존성 주입을 위한 initJWTProvider 메소드 추가
- AbstractOAuthSubject 의존성 주입을 위한 메소드 initObserver 메소드에서  initStrategy 메소드로 변경
- AbstractOAuthObserver OAuthObserver 구현체 주입 메소드 initOAuthObserver로 분리
- AbstractOAuthSubject -> OAuthSubject 로 클래스이름 변경

## 변경로직
- initObserver -> initStrategy{initOAuthObserver, initJWTProvider}

## 참고자료
- 내용을 적어주세요.

