### PR TITLE
Pet 72 Fix : ApplicationEventPublisher 빈등록 및 JpaRepository 빈등록 문제 수정

### DIFF
--- a/Api-Module/src/main/java/com/pawith/apimodule/ApiModuleApplication.java
+++ b/Api-Module/src/main/java/com/pawith/apimodule/ApiModuleApplication.java
@@ -2,13 +2,11 @@ package com.pawith.apimodule;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class })
-@ComponentScan(basePackages = {"com.pawith"})
-@EntityScan(basePackages = {"com.pawith"})
+@ComponentScan(basePackages = "com.pawith")
 public class ApiModuleApplication {
 
     public static void main(String[] args) {

--- a/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/port/out/observer/subject/OAuthSubject.java
+++ b/Auth-Module/auth-application/src/main/java/com/pawith/authmodule/application/port/out/observer/subject/OAuthSubject.java
@@ -71,6 +71,7 @@ public final class OAuthSubject implements Subject<OAuthRequest, OAuthResponse> 
     public void initStrategy(ApplicationContext applicationContext){
         initOAuthObserver(applicationContext);
         initJWTProvider(applicationContext);
+        initEventPublisher(applicationContext);
     }
 
     private void initOAuthObserver(ApplicationContext applicationContext) {
@@ -80,5 +81,9 @@ public final class OAuthSubject implements Subject<OAuthRequest, OAuthResponse> 
     }
     private void initJWTProvider(ApplicationContext applicationContext){
         jwtProvider = applicationContext.getBean(JWT_PROVIDER_BEAN_NAME, JWTProvider.class);
+    }
+
+    private void initEventPublisher(ApplicationContext applicationContext) {
+        publisher = applicationContext;
     }
 }

--- a/Common-Module/src/main/java/com/pawith/commonmodule/config/JpaConfig.java
+++ b/Common-Module/src/main/java/com/pawith/commonmodule/config/JpaConfig.java
@@ -1,0 +1,13 @@
+package com.pawith.commonmodule.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories(basePackages = "com.pawith")
+@EnableJpaAuditing
+@EntityScan(basePackages = "com.pawith")
+public class JpaConfig {
+}

--- a/User-Module/user-application/src/main/java/com/pawith/usermodule/application/handler/UserSignUpHandler.java
+++ b/User-Module/user-application/src/main/java/com/pawith/usermodule/application/handler/UserSignUpHandler.java
@@ -9,9 +9,11 @@ import com.pawith.usermodule.domain.service.UserSaveService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
+@Component
 @RequiredArgsConstructor
 public class UserSignUpHandler {
 

--- a/User-Module/user-domain/src/main/java/com/pawith/usermodule/domain/entity/User.java
+++ b/User-Module/user-domain/src/main/java/com/pawith/usermodule/domain/entity/User.java
@@ -1,20 +1,15 @@
 package com.pawith.usermodule.domain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
+import lombok.*;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
+import javax.persistence.*;
 
 @Builder
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Entity
 public class User extends BaseEntity {
 
     @Id


### PR DESCRIPTION
## 작업사항
- UserRepository 빈등록되지 않는 문제 해결
- OAuthSubject에 ApplicationEventPublisher 빈등록 설정 추가
- EventHandler Component 설정 추가
- User 엔티티 @Entity 애노테이션 추가 및 기본생성자 접근 Protected로 수정
- JpaConfig Common-Module에 추가

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



