### PR TITLE
Pet 89 feat : 사용자 권한 확인 API 추가

### DIFF
--- a/Api-Module/build.gradle
+++ b/Api-Module/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation project(":Log-Module:Log-Aop")
     implementation project(":Auth-Module:Auth-Adaptor")
 
+    implementation project(":Domain-Module:User-Module:User-Presentation")
+
     // 임시 설정
     implementation project(":Auth-Module:JWT")
 }

--- a/Api-Module/src/docs/asciidoc/Index.adoc
+++ b/Api-Module/src/docs/asciidoc/Index.adoc
@@ -7,3 +7,5 @@
 :sectlinks:
 
 include::../../../../Auth-Module/Auth-Adaptor/src/docs/asciidoc/Auth-API.adoc[]
+
+include::../../../../Domain-Module/User-Module/User-Presentation/src/docs/asciidoc/User-API.adoc[]

--- a/Auth-Module/Auth-Adaptor/src/main/java/com/pawith/authmodule/config/security/JWTAuthenticationToken.java
+++ b/Auth-Module/Auth-Adaptor/src/main/java/com/pawith/authmodule/config/security/JWTAuthenticationToken.java
@@ -18,6 +18,6 @@ public class JWTAuthenticationToken extends AbstractAuthenticationToken {
 
     @Override
     public Object getPrincipal() {
-        return null;
+        return email;
     }
 }

--- a/Auth-Module/Auth-Adaptor/src/test/java/com/pawith/authmodule/adaptor/api/OAuthControllerTest.java
+++ b/Auth-Module/Auth-Adaptor/src/test/java/com/pawith/authmodule/adaptor/api/OAuthControllerTest.java
@@ -16,8 +16,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/Common-Module/src/main/java/com/pawith/commonmodule/annotation/ApplicationService.java
+++ b/Common-Module/src/main/java/com/pawith/commonmodule/annotation/ApplicationService.java
@@ -1,0 +1,14 @@
+package com.pawith.commonmodule.annotation;
+
+import org.springframework.stereotype.Service;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Service
+public @interface ApplicationService {
+}

--- a/Common-Module/src/main/java/com/pawith/commonmodule/exception/Error.java
+++ b/Common-Module/src/main/java/com/pawith/commonmodule/exception/Error.java
@@ -14,6 +14,7 @@ public enum Error {
 
     // User
     USER_NOT_FOUND("사용자를 찾을 수 없습니다.", 2000),
+    USER_AUTHORITY_NOT_FOUND("사용자 권한을 찾을 수 없습니다.", 2001),
     ;
 
     private final String message;

--- a/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/application/handler/UserSignUpHandler.java
+++ b/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/application/handler/UserSignUpHandler.java
@@ -3,6 +3,7 @@ package com.pawith.usermodule.application.handler;
 import com.pawith.usermodule.application.handler.event.UserSignUpEvent;
 import com.pawith.usermodule.application.mapper.UserMapper;
 import com.pawith.usermodule.domain.entity.User;
+import com.pawith.usermodule.domain.service.UserAuthoritySaveService;
 import com.pawith.usermodule.domain.service.UserQueryService;
 import com.pawith.usermodule.domain.service.UserSaveService;
 import lombok.RequiredArgsConstructor;
@@ -18,13 +19,15 @@ public class UserSignUpHandler {
 
     private final UserSaveService userSaveService;
     private final UserQueryService userQueryService;
+    private final UserAuthoritySaveService userAuthoritySaveService;
 
     @Transactional
     @EventListener
-    public void signUp(UserSignUpEvent userSignUpEvent){
+    public void signUp(final UserSignUpEvent userSignUpEvent){
         if(!userQueryService.checkEmailAlreadyExist(userSignUpEvent.getEmail())) {
             final User user = UserMapper.toEntity(userSignUpEvent);
             userSaveService.saveUser(user);
+            userAuthoritySaveService.saveUserAuthority(userSignUpEvent.getEmail());
         }
         else {
             userQueryService.checkAccountAlreadyExist(userSignUpEvent.getEmail(), userSignUpEvent.getProvider());

--- a/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/application/service/UserAuthorityGetUseCase.java
+++ b/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/application/service/UserAuthorityGetUseCase.java
@@ -1,0 +1,21 @@
+package com.pawith.usermodule.application.service;
+
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.usermodule.application.service.dto.UserAuthorityInfoResponse;
+import com.pawith.usermodule.domain.entity.UserAuthority;
+import com.pawith.usermodule.domain.service.UserAuthorityQueryService;
+import com.pawith.usermodule.domain.utils.UserUtils;
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class UserAuthorityGetUseCase {
+
+    private final UserAuthorityQueryService userAuthorityQueryService;
+
+    public UserAuthorityInfoResponse getUserAuthority() {
+        final String email = UserUtils.getEmailFromAccessUser();
+        final UserAuthority userAuthority = userAuthorityQueryService.findByEmail(email);
+        return new UserAuthorityInfoResponse(userAuthority.getAuthority());
+    }
+}

--- a/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/application/service/dto/UserAuthorityInfoResponse.java
+++ b/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/application/service/dto/UserAuthorityInfoResponse.java
@@ -1,0 +1,15 @@
+package com.pawith.usermodule.application.service.dto;
+
+import com.pawith.usermodule.domain.entity.Authority;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class UserAuthorityInfoResponse {
+    private final Authority authority;
+
+    public UserAuthorityInfoResponse(Authority authority) {
+        this.authority = authority;
+    }
+}

--- a/Domain-Module/User-Module/User-Application/src/test/java/com/pawith/user/application/handler/UserSignUpHandlerTest.java
+++ b/Domain-Module/User-Module/User-Application/src/test/java/com/pawith/user/application/handler/UserSignUpHandlerTest.java
@@ -6,6 +6,7 @@ import com.pawith.commonmodule.exception.Error;
 import com.pawith.usermodule.application.handler.UserSignUpHandler;
 import com.pawith.usermodule.application.handler.event.UserSignUpEvent;
 import com.pawith.usermodule.domain.exception.AccountAlreadyExistException;
+import com.pawith.usermodule.domain.service.UserAuthoritySaveService;
 import com.pawith.usermodule.domain.service.UserQueryService;
 import com.pawith.usermodule.domain.service.UserSaveService;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,9 @@ public class UserSignUpHandlerTest {
     UserSaveService userSaveService;
     @Mock
     UserQueryService userQueryService;
+    @Mock
+    UserAuthoritySaveService userAuthoritySaveService;
+
     UserSignUpHandler userSignUpHandler;
 
     private static final FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
@@ -43,7 +47,7 @@ public class UserSignUpHandlerTest {
     public static final String PROVIDER = "provider";
 
     @BeforeEach
-    void init() { userSignUpHandler = new UserSignUpHandler(userSaveService, userQueryService); }
+    void init() { userSignUpHandler = new UserSignUpHandler(userSaveService, userQueryService, userAuthoritySaveService); }
 
     @Test
     @DisplayName("첫 로그인 시, 사용자 가입 요청을 처리한다.")
@@ -55,6 +59,7 @@ public class UserSignUpHandlerTest {
         userSignUpHandler.signUp(mockUserSignUpEvent);
         //then
         then(userSaveService).should(times(1)).saveUser(any());
+        then(userAuthoritySaveService).should(times(1)).saveUserAuthority(any());
     }
 
     @Test

--- a/Domain-Module/User-Module/User-Domain/build.gradle
+++ b/Domain-Module/User-Module/User-Domain/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+}

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/entity/Authority.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/entity/Authority.java
@@ -1,0 +1,5 @@
+package com.pawith.usermodule.domain.entity;
+
+public enum Authority {
+    GUEST, USER, ADMIN
+}

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/entity/UserAuthority.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/entity/UserAuthority.java
@@ -1,0 +1,32 @@
+package com.pawith.usermodule.domain.entity;
+
+import com.pawith.commonmodule.domain.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserAuthority extends BaseEntity {
+    @Id@GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_authority_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Authority authority;
+    private String email;
+
+    public UserAuthority(String email) {
+        this.authority = Authority.GUEST;
+        this.email = email;
+    }
+
+    public void changeUserAuthority(){
+        this.authority = Authority.USER;
+    }
+}

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/exception/UserAuthorityNotFoundException.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/exception/UserAuthorityNotFoundException.java
@@ -1,0 +1,9 @@
+package com.pawith.usermodule.domain.exception;
+
+import com.pawith.commonmodule.exception.Error;
+
+public class UserAuthorityNotFoundException extends UserException{
+    public UserAuthorityNotFoundException(Error error) {
+        super(error);
+    }
+}

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/repository/UserAuthorityRepository.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/repository/UserAuthorityRepository.java
@@ -1,0 +1,11 @@
+package com.pawith.usermodule.domain.repository;
+
+import com.pawith.usermodule.domain.entity.UserAuthority;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserAuthorityRepository extends JpaRepository<UserAuthority, Long> {
+
+    Optional<UserAuthority> findByEmail(String email);
+}

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/service/UserAuthorityQueryService.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/service/UserAuthorityQueryService.java
@@ -1,0 +1,20 @@
+package com.pawith.usermodule.domain.service;
+
+import com.pawith.commonmodule.annotation.DomainService;
+import com.pawith.commonmodule.exception.Error;
+import com.pawith.usermodule.domain.entity.UserAuthority;
+import com.pawith.usermodule.domain.exception.UserAuthorityNotFoundException;
+import com.pawith.usermodule.domain.repository.UserAuthorityRepository;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class UserAuthorityQueryService {
+    private final UserAuthorityRepository userAuthorityRepository;
+
+    public UserAuthority findByEmail(final String email) {
+        final UserAuthority userAuthority = userAuthorityRepository.findByEmail(email)
+            .orElseThrow(() -> new UserAuthorityNotFoundException(Error.USER_AUTHORITY_NOT_FOUND));
+        return userAuthority;
+    }
+}

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/service/UserAuthoritySaveService.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/service/UserAuthoritySaveService.java
@@ -1,0 +1,17 @@
+package com.pawith.usermodule.domain.service;
+
+import com.pawith.commonmodule.annotation.DomainService;
+import com.pawith.usermodule.domain.entity.UserAuthority;
+import com.pawith.usermodule.domain.repository.UserAuthorityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@DomainService
+@RequiredArgsConstructor
+public class UserAuthoritySaveService {
+    private final UserAuthorityRepository userAuthorityRepository;
+
+    public void saveUserAuthority(final String email) {
+        userAuthorityRepository.save(new UserAuthority(email));
+    }
+}

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/utils/UserUtils.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/utils/UserUtils.java
@@ -1,0 +1,32 @@
+package com.pawith.usermodule.domain.utils;
+
+import com.pawith.usermodule.domain.entity.User;
+import com.pawith.usermodule.domain.service.UserQueryService;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserUtils {
+
+    private static UserQueryService userQueryService;
+
+    public UserUtils(UserQueryService userQueryService) {
+        UserUtils.userQueryService = userQueryService;
+    }
+
+    public static User getAccessUser(){
+        final String email = getCurrentUserEmail();
+        return userQueryService.findByEmail(email);
+    }
+
+    private static String getCurrentUserEmail() {
+        final String email = (String)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return email;
+    }
+
+    public static String getEmailFromAccessUser(){
+        return getCurrentUserEmail();
+    }
+}

--- a/Domain-Module/User-Module/User-Presentation/build.gradle
+++ b/Domain-Module/User-Module/User-Presentation/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation project(':Domain-Module:User-Module:User-Application')
+
+    implementation project(':Common-Module:Test-Module')
+}

--- a/Domain-Module/User-Module/User-Presentation/src/docs/asciidoc/User-API.adoc
+++ b/Domain-Module/User-Module/User-Presentation/src/docs/asciidoc/User-API.adoc
@@ -1,0 +1,7 @@
+[[User-API]]
+== User-API
+
+[[UserAuthorityController]]
+=== 사용자 권한 확인
+
+operation::user-authority-controller-test/get-user-authority[snippents='http-request.adoc,http-response.adoc']

--- a/Domain-Module/User-Module/User-Presentation/src/main/java/com/pawith/userpresentation/UserAuthorityController.java
+++ b/Domain-Module/User-Module/User-Presentation/src/main/java/com/pawith/userpresentation/UserAuthorityController.java
@@ -1,0 +1,21 @@
+package com.pawith.userpresentation;
+
+import com.pawith.usermodule.application.service.UserAuthorityGetUseCase;
+import com.pawith.usermodule.application.service.dto.UserAuthorityInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserAuthorityController {
+    private final UserAuthorityGetUseCase userAuthorityGetUseCase;
+
+
+    @GetMapping("/authority")
+    public UserAuthorityInfoResponse getUserAuthority() {
+        return userAuthorityGetUseCase.getUserAuthority();
+    }
+}

--- a/Domain-Module/User-Module/User-Presentation/src/test/java/com/pawith/userpresentation/TestSpringBootApplicationConfig.java
+++ b/Domain-Module/User-Module/User-Presentation/src/test/java/com/pawith/userpresentation/TestSpringBootApplicationConfig.java
@@ -1,0 +1,7 @@
+package com.pawith.userpresentation;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestSpringBootApplicationConfig {
+}

--- a/Domain-Module/User-Module/User-Presentation/src/test/java/com/pawith/userpresentation/UserAuthorityControllerTest.java
+++ b/Domain-Module/User-Module/User-Presentation/src/test/java/com/pawith/userpresentation/UserAuthorityControllerTest.java
@@ -1,0 +1,66 @@
+package com.pawith.userpresentation;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.pawith.testmodule.BaseRestDocsTest;
+import com.pawith.usermodule.application.service.UserAuthorityGetUseCase;
+import com.pawith.usermodule.application.service.dto.UserAuthorityInfoResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserAuthorityController.class)
+@DisplayName("UserAuthorityController 테스트")
+public class UserAuthorityControllerTest extends BaseRestDocsTest {
+
+    private static final String USER_AUTHORITY_URL = "/user/authority";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String AUTHORIZATION_HEADER_VALUE = "Bearer ";
+
+    @MockBean
+    UserAuthorityGetUseCase userAuthorityGetUseCase;
+
+
+
+    @Test
+    @DisplayName("사용자 권한 조회")
+    void getUserAuthority() throws Exception {
+        //given
+        final UserAuthorityInfoResponse testUserAuthorityInfoResponse = getFixtureMonkey().giveMeOne(UserAuthorityInfoResponse.class);
+        given(userAuthorityGetUseCase.getUserAuthority()).willReturn(testUserAuthorityInfoResponse);
+        MockHttpServletRequestBuilder request = get(USER_AUTHORITY_URL)
+            .header(AUTHORIZATION_HEADER, AUTHORIZATION_HEADER_VALUE + FixtureMonkey.create().giveMeOne(String.class));
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+            .andDo(print())
+            .andDo(resultHandler.document(
+                requestHeaders(
+                    headerWithName(AUTHORIZATION_HEADER).description("access 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("authority").description("사용자 권한")
+                )
+            ));
+    }
+
+    private FixtureMonkey getFixtureMonkey() {
+        return FixtureMonkey.builder()
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .build();
+    }
+}


### PR DESCRIPTION
## 작업사항
- UserAuthority Domain(Entity, Repository, Service, Exception) 추가
- UserAuthority Application(유저 권한 반환 usecase) 추가
- UserAuthority Presentation(유저 권한 조회 API)추가 및 테스트 추가
- User-API 명세 추가
- Authentication.getPricipal()에서 null 반환하는 문제 수정

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



