### PR TITLE
Pet 92 refactor : Test-Module 제거 및 testFixture 패키지 추가

### DIFF
--- a/Auth-Module/Auth-Adaptor/build.gradle
+++ b/Auth-Module/Auth-Adaptor/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
     implementation project(":Auth-Module:Auth-Application")
+    testImplementation(testFixtures(project(':Common-Module')))
 }

--- a/Auth-Module/Auth-Adaptor/src/test/java/com/pawith/authmodule/adaptor/api/OAuthControllerTest.java
+++ b/Auth-Module/Auth-Adaptor/src/test/java/com/pawith/authmodule/adaptor/api/OAuthControllerTest.java
@@ -5,7 +5,7 @@ import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitra
 import com.pawith.authmodule.application.dto.OAuthResponse;
 import com.pawith.authmodule.application.dto.Provider;
 import com.pawith.authmodule.application.port.in.OAuthUseCase;
-import com.pawith.testmodule.BaseRestDocsTest;
+import com.pawith.commonmodule.BaseRestDocsTest;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +16,8 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/Auth-Module/build.gradle
+++ b/Auth-Module/build.gradle
@@ -1,8 +1,6 @@
 subprojects {
     dependencies {
         implementation project(":Common-Module")
-        testImplementation project(":Common-Module:Test-Module")
-
 
         // spring security
         implementation "org.springframework.boot:spring-boot-starter-security"

--- a/Common-Module/build.gradle
+++ b/Common-Module/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    //restdocs
+}

--- a/Common-Module/src/main/java/com/pawith/commonmodule/util/SecurityUtils.java
+++ b/Common-Module/src/main/java/com/pawith/commonmodule/util/SecurityUtils.java
@@ -1,0 +1,13 @@
+package com.pawith.commonmodule.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SecurityUtils {
+
+    public static String getAuthenticationPrincipal() {
+        final String email = (String) org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return email;
+    }
+}

--- a/Common-Module/src/testFixtures/java/com/pawith/commonmodule/BaseRestDocsTest.java
+++ b/Common-Module/src/testFixtures/java/com/pawith/commonmodule/BaseRestDocsTest.java
@@ -1,4 +1,4 @@
-package com.pawith.testmodule;
+package com.pawith.commonmodule;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,7 +13,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 @AutoConfigureRestDocs
 @Import({RestDocsConfig.class})
@@ -32,7 +31,7 @@ public class BaseRestDocsTest {
             .apply(MockMvcRestDocumentation.documentationConfiguration(provider).uris().withPort(8080))
             .alwaysDo(MockMvcResultHandlers.print())
             .alwaysDo(resultHandler)
-            .addFilters(new CharacterEncodingFilter("UTF-8", true))
+//            .addFilters(new CharacterEncodingFilter("UTF-8", true))
             .build();
     }
 

--- a/Common-Module/src/testFixtures/java/com/pawith/commonmodule/RestDocsConfig.java
+++ b/Common-Module/src/testFixtures/java/com/pawith/commonmodule/RestDocsConfig.java
@@ -1,4 +1,4 @@
-package com.pawith.testmodule;
+package com.pawith.commonmodule;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;

--- a/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/application/service/UserAuthorityGetUseCase.java
+++ b/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/application/service/UserAuthorityGetUseCase.java
@@ -4,7 +4,7 @@ import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.usermodule.application.service.dto.UserAuthorityInfoResponse;
 import com.pawith.usermodule.domain.entity.UserAuthority;
 import com.pawith.usermodule.domain.service.UserAuthorityQueryService;
-import com.pawith.usermodule.domain.utils.UserUtils;
+import com.pawith.usermodule.utils.UserUtils;
 import lombok.RequiredArgsConstructor;
 
 @ApplicationService

--- a/Domain-Module/User-Module/User-Domain/build.gradle
+++ b/Domain-Module/User-Module/User-Domain/build.gradle
@@ -1,4 +1,0 @@
-dependencies {
-    // security
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-}

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/utils/UserUtils.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/utils/UserUtils.java
@@ -5,7 +5,9 @@ import com.pawith.usermodule.domain.entity.User;
 import com.pawith.usermodule.domain.service.UserQueryService;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 
+@Component
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserUtils {
 

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/utils/UserUtils.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/utils/UserUtils.java
@@ -1,11 +1,10 @@
-package com.pawith.usermodule.domain.utils;
+package com.pawith.usermodule.utils;
 
+import com.pawith.commonmodule.util.SecurityUtils;
 import com.pawith.usermodule.domain.entity.User;
 import com.pawith.usermodule.domain.service.UserQueryService;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserUtils {
@@ -17,16 +16,11 @@ public class UserUtils {
     }
 
     public static User getAccessUser(){
-        final String email = getCurrentUserEmail();
+        final String email = SecurityUtils.getAuthenticationPrincipal();
         return userQueryService.findByEmail(email);
     }
 
-    private static String getCurrentUserEmail() {
-        final String email = (String)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return email;
-    }
-
     public static String getEmailFromAccessUser(){
-        return getCurrentUserEmail();
+        return SecurityUtils.getAuthenticationPrincipal();
     }
 }

--- a/Domain-Module/User-Module/User-Presentation/build.gradle
+++ b/Domain-Module/User-Module/User-Presentation/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation project(':Domain-Module:User-Module:User-Application')
 
-    implementation project(':Common-Module:Test-Module')
+    testImplementation(testFixtures(project(':Common-Module')))
 }

--- a/Domain-Module/User-Module/User-Presentation/src/test/java/com/pawith/userpresentation/UserAuthorityControllerTest.java
+++ b/Domain-Module/User-Module/User-Presentation/src/test/java/com/pawith/userpresentation/UserAuthorityControllerTest.java
@@ -2,10 +2,9 @@ package com.pawith.userpresentation;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
-import com.pawith.testmodule.BaseRestDocsTest;
+import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.usermodule.application.service.UserAuthorityGetUseCase;
 import com.pawith.usermodule.application.service.dto.UserAuthorityInfoResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -17,8 +16,8 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id "java-test-fixtures"
     id 'org.springframework.boot' version '2.7.13'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'

--- a/gradle/restdocs.gradle
+++ b/gradle/restdocs.gradle
@@ -3,6 +3,7 @@ subprojects {
         // restdocs
         asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
         implementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+        testFixturesImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     }
 
     // RestDocs 설정

--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -5,6 +5,7 @@ springBoot {
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'java-test-fixtures'
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'org.asciidoctor.jvm.convert'
@@ -25,7 +26,6 @@ subprojects {
 
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-web'
-        implementation 'org.springframework.boot:spring-boot-starter-test'
         // jpa
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         runtimeOnly 'com.mysql:mysql-connector-j'

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -2,5 +2,9 @@ subprojects {
     dependencies {
         // Fixture testing tool
         testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:0.6.3")
+
+        // mvc
+        implementation 'org.springframework.boot:spring-boot-starter-test'
+        testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test'
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,4 +24,3 @@ include 'Domain-Module:Todo-Module:Todo-Application'
 include 'Domain-Module:Todo-Module:Todo-Presentation'
 
 include 'Common-Module'
-include 'Common-Module:Test-Module'


### PR DESCRIPTION
## 작업사항
- Test-Module 제거 후 RestDocs 설정 파일 Common-Module의 testFixture 패키지에서 관리하도록 수정
- UserUtils가 Security 의존성 가지지 않도록 수정
- Common-Module에 SecurityUtils추가

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



