### PR TITLE
Pet 93 test : Unit Test용 애노테이션 및 테스트 환경에서 SecurityContextHolder에 인증 사용자 정보 주입 애노테이션 추가

### DIFF
--- a/Auth-Module/Auth-Application/src/test/java/com/pawith/auth/application/JWTExtractEmailServiceTest.java
+++ b/Auth-Module/Auth-Application/src/test/java/com/pawith/auth/application/JWTExtractEmailServiceTest.java
@@ -2,21 +2,18 @@ package com.pawith.auth.application;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.pawith.authmodule.application.service.JWTExtractEmailService;
+import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.jwt.JWTProvider;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-@Slf4j
-@ExtendWith(MockitoExtension.class)
+@UnitTestConfig
 @DisplayName("JWTExtractEmailService 테스트")
 public class JWTExtractEmailServiceTest {
 

--- a/Auth-Module/Auth-Application/src/test/java/com/pawith/auth/application/JWTExtractTokenServiceTest.java
+++ b/Auth-Module/Auth-Application/src/test/java/com/pawith/auth/application/JWTExtractTokenServiceTest.java
@@ -2,18 +2,15 @@ package com.pawith.auth.application;
 
 import com.pawith.authmodule.application.common.exception.InvalidAuthorizationTypeException;
 import com.pawith.authmodule.application.service.JWTExtractTokenService;
-import lombok.extern.slf4j.Slf4j;
+import com.pawith.commonmodule.UnitTestConfig;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Slf4j
-@ExtendWith(MockitoExtension.class)
+@UnitTestConfig
 @DisplayName("JWTExtractTokenService 테스트")
 public class JWTExtractTokenServiceTest {
 

--- a/Auth-Module/Auth-Application/src/test/java/com/pawith/auth/application/JWTVerifyServiceTest.java
+++ b/Auth-Module/Auth-Application/src/test/java/com/pawith/auth/application/JWTVerifyServiceTest.java
@@ -2,20 +2,17 @@ package com.pawith.auth.application;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.pawith.authmodule.application.service.JWTVerifyService;
+import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.jwt.JWTProvider;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
-@Slf4j
-@ExtendWith(MockitoExtension.class)
+@UnitTestConfig
 @DisplayName("JWTVerifyService 테스트")
 public class JWTVerifyServiceTest {
 

--- a/Auth-Module/Auth-Application/src/test/java/com/pawith/auth/application/OAuthServiceTest.java
+++ b/Auth-Module/Auth-Application/src/test/java/com/pawith/auth/application/OAuthServiceTest.java
@@ -1,28 +1,20 @@
 package com.pawith.auth.application;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
-import com.pawith.authmodule.application.dto.OAuthRequest;
-import com.pawith.authmodule.application.dto.OAuthResponse;
 import com.pawith.authmodule.application.dto.Provider;
 import com.pawith.authmodule.application.port.out.command.OAuthInvoker;
 import com.pawith.authmodule.application.service.OAuthService;
-import lombok.extern.slf4j.Slf4j;
+import com.pawith.commonmodule.UnitTestConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
 
-@Slf4j
-@ExtendWith(MockitoExtension.class)
+@UnitTestConfig
 @DisplayName("OAuthService 테스트")
 public class OAuthServiceTest {
 

--- a/Auth-Module/JWT/src/test/java/com/pawith/jwt/JWTProviderTest.java
+++ b/Auth-Module/JWT/src/test/java/com/pawith/jwt/JWTProviderTest.java
@@ -1,6 +1,7 @@
 package com.pawith.jwt;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.commonmodule.cache.ObjectRegistry;
 import com.pawith.jwt.exception.ExpiredTokenException;
 import com.pawith.jwt.exception.InvalidTokenException;
@@ -11,21 +12,17 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
 import static org.mockito.BDDMockito.given;
 
-@Slf4j
-@ExtendWith(MockitoExtension.class)
+@UnitTestConfig
 @DisplayName("JWTProvider 테스트")
 public class JWTProviderTest {
     private final JWTProperties jwtProperties = new JWTProperties(JWTTestConsts.SECRET, JWTTestConsts.ACCESS_TOKEN_EXPIRED_TIME, JWTTestConsts.REFRESH_TOKEN_EXPIRED_TIME);
@@ -48,7 +45,6 @@ public class JWTProviderTest {
         //when
         final Claims body = extractClaimsFromToken(accessToken);
         //then
-        log.info("email: {}",randomEmail);
         Assertions.assertThat(body.get(JWTConsts.EMAIL)).isEqualTo(randomEmail);
         Assertions.assertThat(body.get(JWTConsts.TOKEN_TYPE)).isEqualTo(TokenType.ACCESS_TOKEN.toString());
     }

--- a/Auth-Module/build.gradle
+++ b/Auth-Module/build.gradle
@@ -1,6 +1,7 @@
 subprojects {
     dependencies {
         implementation project(":Common-Module")
+        testImplementation(testFixtures(project(':Common-Module')))
 
         // spring security
         implementation "org.springframework.boot:spring-boot-starter-security"

--- a/Common-Module/build.gradle
+++ b/Common-Module/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    testFixturesImplementation 'org.springframework.security:spring-security-test'
     //restdocs
 }

--- a/Common-Module/src/main/java/com/pawith/commonmodule/util/SecurityUtils.java
+++ b/Common-Module/src/main/java/com/pawith/commonmodule/util/SecurityUtils.java
@@ -2,12 +2,13 @@ package com.pawith.commonmodule.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SecurityUtils {
 
     public static String getAuthenticationPrincipal() {
-        final String email = (String) org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final String email = (String)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         return email;
     }
 }

--- a/Common-Module/src/testFixtures/java/com/pawith/commonmodule/UnitTestConfig.java
+++ b/Common-Module/src/testFixtures/java/com/pawith/commonmodule/UnitTestConfig.java
@@ -1,0 +1,18 @@
+package com.pawith.commonmodule;
+
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith({MockitoExtension.class})
+@SpringJUnitConfig // https://stackoverflow.com/questions/69175844/spring-security-test-withmockuser-not-working
+public @interface UnitTestConfig {
+}

--- a/Common-Module/src/testFixtures/java/com/pawith/commonmodule/security/WithMockAuthUser.java
+++ b/Common-Module/src/testFixtures/java/com/pawith/commonmodule/security/WithMockAuthUser.java
@@ -1,0 +1,15 @@
+package com.pawith.commonmodule.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockAuthUserSecurityContextFactory.class)
+public @interface WithMockAuthUser {
+    String email() default "email";
+}

--- a/Common-Module/src/testFixtures/java/com/pawith/commonmodule/security/WithMockAuthUserSecurityContextFactory.java
+++ b/Common-Module/src/testFixtures/java/com/pawith/commonmodule/security/WithMockAuthUserSecurityContextFactory.java
@@ -1,0 +1,32 @@
+package com.pawith.commonmodule.security;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public final class WithMockAuthUserSecurityContextFactory implements WithSecurityContextFactory<WithMockAuthUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockAuthUser annotation) {
+        final SecurityContext emptyContext = SecurityContextHolder.createEmptyContext();
+        emptyContext.setAuthentication(new AbstractAuthenticationToken(null) {
+            @Override
+            public Object getCredentials() {
+                return null;
+            }
+
+            @Override
+            public Object getPrincipal() {
+                return annotation.email().equals("email") ? FixtureMonkey.create().giveMeOne(String.class):annotation.email();
+            }
+
+            @Override
+            public boolean isAuthenticated() {
+                return true;
+            }
+        });
+        return emptyContext;
+    }
+}

--- a/Domain-Module/User-Module/User-Application/src/test/java/com/pawith/usermodule/application/handler/UserSignUpHandlerTest.java
+++ b/Domain-Module/User-Module/User-Application/src/test/java/com/pawith/usermodule/application/handler/UserSignUpHandlerTest.java
@@ -1,9 +1,9 @@
-package com.pawith.user.application.handler;
+package com.pawith.usermodule.application.handler;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.commonmodule.exception.Error;
-import com.pawith.usermodule.application.handler.UserSignUpHandler;
 import com.pawith.usermodule.application.handler.event.UserSignUpEvent;
 import com.pawith.usermodule.domain.exception.AccountAlreadyExistException;
 import com.pawith.usermodule.domain.service.UserAuthoritySaveService;
@@ -14,10 +14,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -25,8 +22,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 
-@Slf4j
-@ExtendWith(MockitoExtension.class)
+@UnitTestConfig
 @DisplayName("UserSignUpHandler 테스트")
 public class UserSignUpHandlerTest {
 

--- a/Domain-Module/User-Module/User-Application/src/test/java/com/pawith/usermodule/application/service/UserAuthorityGetUseCaseTest.java
+++ b/Domain-Module/User-Module/User-Application/src/test/java/com/pawith/usermodule/application/service/UserAuthorityGetUseCaseTest.java
@@ -1,0 +1,50 @@
+package com.pawith.usermodule.application.service;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.pawith.commonmodule.UnitTestConfig;
+import com.pawith.commonmodule.security.WithMockAuthUser;
+import com.pawith.usermodule.application.service.dto.UserAuthorityInfoResponse;
+import com.pawith.usermodule.domain.entity.UserAuthority;
+import com.pawith.usermodule.domain.service.UserAuthorityQueryService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@UnitTestConfig
+@DisplayName("UserAuthorityGetUseCase 테스트")
+class UserAuthorityGetUseCaseTest {
+
+    @Mock
+    UserAuthorityQueryService userAuthorityQueryService;
+
+    UserAuthorityGetUseCase userAuthorityGetUseCase;
+
+    private static final String MOCK_EMAIL = "email";
+
+    @BeforeEach
+    void init() {
+        userAuthorityGetUseCase = new UserAuthorityGetUseCase(userAuthorityQueryService);
+    }
+
+    @Test
+    @WithMockAuthUser
+    @DisplayName("유저 권한을 조회한다.")
+    void getUserAuthority() {
+        //given
+        final UserAuthority userAuthority = FixtureMonkey.builder().objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE).defaultNotNull(true).build()
+            .giveMeBuilder(UserAuthority.class)
+            .sample();
+        given(userAuthorityQueryService.findByEmail(anyString())).willReturn(userAuthority);
+        //when
+        UserAuthorityInfoResponse result = userAuthorityGetUseCase.getUserAuthority();
+        //then
+        Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(new UserAuthorityInfoResponse(userAuthority.getAuthority()));
+    }
+
+}

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/entity/UserAuthority.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/domain/entity/UserAuthority.java
@@ -1,16 +1,13 @@
 package com.pawith.usermodule.domain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.junit.jupiter.api.DisplayName;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserAuthority extends BaseEntity {
     @Id@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Domain-Module/User-Module/User-Domain/src/test/java/com/pawith/usermodule/domain/service/UserAuthorityQueryServiceTest.java
+++ b/Domain-Module/User-Module/User-Domain/src/test/java/com/pawith/usermodule/domain/service/UserAuthorityQueryServiceTest.java
@@ -1,0 +1,69 @@
+package com.pawith.usermodule.domain.service;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.pawith.commonmodule.UnitTestConfig;
+import com.pawith.usermodule.domain.entity.UserAuthority;
+import com.pawith.usermodule.domain.exception.UserAuthorityNotFoundException;
+import com.pawith.usermodule.domain.repository.UserAuthorityRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+
+@UnitTestConfig
+@DisplayName("UserAuthorityQueryService 테스트")
+class UserAuthorityQueryServiceTest {
+
+    @Mock
+    UserAuthorityRepository userAuthorityRepository;
+
+    UserAuthorityQueryService userAuthorityQueryService;
+
+    private static FixtureMonkey getFixtureMonkey() {
+        return FixtureMonkey.builder()
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .defaultNotNull(true)
+            .build();
+    }
+
+    @BeforeEach
+    void init() {
+        userAuthorityQueryService = new UserAuthorityQueryService(userAuthorityRepository);
+    }
+
+    @Test
+    @DisplayName("유저 권한을 조회한다.")
+    void findByEmail() {
+        //given
+        final String email = FixtureMonkey.create().giveMeOne(String.class);
+        final UserAuthority userAuthority = getFixtureMonkey()
+            .giveMeBuilder(UserAuthority.class)
+            .set("email", email)
+            .sample();
+        given(userAuthorityRepository.findByEmail(email)).willReturn(Optional.of(userAuthority));
+        //when
+        UserAuthority result = userAuthorityQueryService.findByEmail(email);
+        //then
+        Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(userAuthority);
+        Assertions.assertThat(result.getEmail()).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("유저 권한을 조회할 수 없으면 예외가 발생한다.")
+    void findByEmailThrowException() {
+        //given
+        final String email = FixtureMonkey.create().giveMeOne(String.class);
+        given(userAuthorityRepository.findByEmail(email)).willReturn(Optional.empty());
+        //when
+        //then
+        Assertions.assertThatCode(() -> userAuthorityQueryService.findByEmail(email))
+            .isInstanceOf(UserAuthorityNotFoundException.class);
+    }
+
+}

--- a/Domain-Module/User-Module/User-Domain/src/test/java/com/pawith/usermodule/domain/service/UserAuthorityQueryServiceTest.java
+++ b/Domain-Module/User-Module/User-Domain/src/test/java/com/pawith/usermodule/domain/service/UserAuthorityQueryServiceTest.java
@@ -6,6 +6,7 @@ import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.usermodule.domain.entity.UserAuthority;
 import com.pawith.usermodule.domain.exception.UserAuthorityNotFoundException;
 import com.pawith.usermodule.domain.repository.UserAuthorityRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +17,7 @@ import java.util.Optional;
 
 import static org.mockito.BDDMockito.given;
 
+@Slf4j
 @UnitTestConfig
 @DisplayName("UserAuthorityQueryService 테스트")
 class UserAuthorityQueryServiceTest {
@@ -51,7 +53,6 @@ class UserAuthorityQueryServiceTest {
         UserAuthority result = userAuthorityQueryService.findByEmail(email);
         //then
         Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(userAuthority);
-        Assertions.assertThat(result.getEmail()).isEqualTo(email);
     }
 
     @Test

--- a/Domain-Module/User-Module/User-Domain/src/test/java/com/pawith/usermodule/domain/service/UserAuthoritySaveServiceTest.java
+++ b/Domain-Module/User-Module/User-Domain/src/test/java/com/pawith/usermodule/domain/service/UserAuthoritySaveServiceTest.java
@@ -1,0 +1,39 @@
+package com.pawith.usermodule.domain.service;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.pawith.commonmodule.UnitTestConfig;
+import com.pawith.usermodule.domain.repository.UserAuthorityRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+
+@UnitTestConfig
+@DisplayName("UserAuthoritySaveService 테스트")
+class UserAuthoritySaveServiceTest {
+
+    @Mock
+    UserAuthorityRepository userAuthorityRepository;
+
+    UserAuthoritySaveService userAuthoritySaveService;
+
+    @BeforeEach
+    void init() {
+        userAuthoritySaveService = new UserAuthoritySaveService(userAuthorityRepository);
+    }
+
+    @Test
+    @DisplayName("유저 권한을 생성한다.")
+    void saveUserAuthority() {
+        //given
+        final String email = FixtureMonkey.create().giveMeOne(String.class);
+        //when
+        userAuthoritySaveService.saveUserAuthority(email);
+        //then
+        then(userAuthorityRepository).should().save(any());
+    }
+
+}

--- a/Domain-Module/User-Module/User-Domain/src/test/java/com/pawith/usermodule/domain/service/UserQueryServiceTest.java
+++ b/Domain-Module/User-Module/User-Domain/src/test/java/com/pawith/usermodule/domain/service/UserQueryServiceTest.java
@@ -1,28 +1,22 @@
-package com.pawith.user.domain;
+package com.pawith.usermodule.domain.service;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.usermodule.domain.entity.User;
-import com.pawith.usermodule.domain.exception.AccountAlreadyExistException;
 import com.pawith.usermodule.domain.repository.UserRepository;
-import com.pawith.usermodule.domain.service.UserQueryService;
-import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 
-@Slf4j
-@ExtendWith(MockitoExtension.class)
+@UnitTestConfig
 @DisplayName("UserQueryService 테스트")
 public class UserQueryServiceTest {
 

--- a/Domain-Module/User-Module/User-Domain/src/test/java/com/pawith/usermodule/domain/service/UserSaveServiceTest.java
+++ b/Domain-Module/User-Module/User-Domain/src/test/java/com/pawith/usermodule/domain/service/UserSaveServiceTest.java
@@ -1,24 +1,20 @@
-package com.pawith.user.domain;
+package com.pawith.usermodule.domain.service;
 
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.usermodule.domain.entity.User;
 import com.pawith.usermodule.domain.repository.UserRepository;
-import com.pawith.usermodule.domain.service.UserSaveService;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
-@Slf4j
-@ExtendWith(MockitoExtension.class)
+@UnitTestConfig
 @DisplayName("UserSaveService 테스트")
 public class UserSaveServiceTest {
 

--- a/Domain-Module/User-Module/User-Presentation/build.gradle
+++ b/Domain-Module/User-Module/User-Presentation/build.gradle
@@ -1,5 +1,3 @@
 dependencies {
     implementation project(':Domain-Module:User-Module:User-Application')
-
-    testImplementation(testFixtures(project(':Common-Module')))
 }

--- a/Domain-Module/User-Module/build.gradle
+++ b/Domain-Module/User-Module/build.gradle
@@ -1,5 +1,6 @@
 subprojects {
     dependencies {
         implementation project(":Common-Module")
+        testImplementation(testFixtures(project(':Common-Module')))
     }
 }

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -2,6 +2,7 @@ subprojects {
     dependencies {
         // Fixture testing tool
         testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:0.6.3")
+        testFixturesImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:0.6.3")
 
         // mvc
         implementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
## 작업사항
- UnitTest용 @UnitTestConfig 애노테이션 추가
- 테스트 환경에서 SecurityContextHolder에 사용자 정보 주입 @WithMockAuthUser 애노테이션 추가
- 모든 Unit Test에 @UnitTestConfig 적용
- 테스트 패키지 구조 수정

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



