### PR TITLE
PET-101 fix : JWTAuthenticationFilter에서 발생하는 예외 service에서 발생하도록 수정

### DIFF
--- a/Auth-Module/Auth-Application/src/main/java/com/pawith/authmodule/application/service/impl/JWTExtractTokenService.java
+++ b/Auth-Module/Auth-Application/src/main/java/com/pawith/authmodule/application/service/impl/JWTExtractTokenService.java
@@ -1,17 +1,24 @@
 package com.pawith.authmodule.application.service.impl;
 
-import com.pawith.authmodule.common.consts.AuthConsts;
-import com.pawith.authmodule.application.service.JWTExtractTokenUseCase;
-import com.pawith.commonmodule.exception.Error;
 import com.pawith.authmodule.application.exception.InvalidAuthorizationTypeException;
+import com.pawith.authmodule.application.service.JWTExtractTokenUseCase;
+import com.pawith.authmodule.common.consts.AuthConsts;
+import com.pawith.commonmodule.exception.Error;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.Objects;
 
+@Slf4j
 @Service
 public class JWTExtractTokenService implements JWTExtractTokenUseCase {
     @Override
     public String extractToken(final String tokenHeader) {
+        if(!StringUtils.hasText(tokenHeader)){
+            throw new InvalidAuthorizationTypeException(Error.EMPTY_AUTHORIZATION_HEADER);
+        }
+
         final String[] splitToken = tokenHeader.split(" ");
         final String authorizationType = splitToken[0];
         final String accessToken = splitToken[1];

--- a/Auth-Module/Auth-Application/src/main/java/com/pawith/authmodule/common/consts/AuthConsts.java
+++ b/Auth-Module/Auth-Application/src/main/java/com/pawith/authmodule/common/consts/AuthConsts.java
@@ -7,4 +7,5 @@ import lombok.NoArgsConstructor;
 public class AuthConsts {
     public static final String AUTHENTICATION_TYPE= "Bearer";
     public static final String AUTHORIZATION = "Authorization";
+    public static final String EMPTY_HEADER = null;
 }

--- a/Auth-Module/Auth-Presentation/src/main/java/com/pawith/authmodule/common/security/filter/JWTAuthenticationFilter.java
+++ b/Auth-Module/Auth-Presentation/src/main/java/com/pawith/authmodule/common/security/filter/JWTAuthenticationFilter.java
@@ -1,13 +1,11 @@
 package com.pawith.authmodule.common.security.filter;
 
-import com.pawith.authmodule.common.consts.AuthConsts;
-import com.pawith.authmodule.common.consts.IgnoredPathConsts;
-import com.pawith.authmodule.application.exception.InvalidAuthorizationTypeException;
 import com.pawith.authmodule.application.service.JWTExtractEmailUseCase;
 import com.pawith.authmodule.application.service.JWTExtractTokenUseCase;
 import com.pawith.authmodule.application.service.JWTVerifyUseCase;
+import com.pawith.authmodule.common.consts.AuthConsts;
+import com.pawith.authmodule.common.consts.IgnoredPathConsts;
 import com.pawith.authmodule.common.security.JWTAuthenticationToken;
-import com.pawith.commonmodule.exception.Error;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -46,8 +44,7 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
 
     private String getTokenFromHeader(HttpServletRequest request){
         String header = request.getHeader(AuthConsts.AUTHORIZATION);
-        if(StringUtils.hasText(header)) return header;
-        throw new InvalidAuthorizationTypeException(Error.EMPTY_AUTHORIZATION_HEADER);
+        return StringUtils.hasText(header)? header : AuthConsts.EMPTY_HEADER;
     }
 
     private Boolean isIgnoredPath(HttpServletRequest request){


### PR DESCRIPTION
## 작업사항
- Filter에서 발생하는 예외는 AOP로 잡을 수 없기에 Service에서 예외를 던지도록 수정

## 변경로직
- JWTAuthenticationFilter throws InvalidAuthorizationTypeException
 -> JWTExtractTokenService throws InvalidAuthorizationTypeException

## 참고자료
- 내용을 적어주세요.



