### PR TITLE
Pet 99 feat : 유저 프로필 이미지 수정 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,14 @@ out/
 
 ### application ###
 /Api-Module/src/main/resources/application.yml
+**/src/main/resources/application.yml
+**/src/main/resources/application.properties
 
 ### resources static docs ###
 **/src/main/resources/static/docs/
 
 ### logs ###
 logs/logback/*
+
+### jqwik ###
+**/.jqwik-database

--- a/Api-Module/build.gradle
+++ b/Api-Module/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation project(":Domain-Module:Todo-Module:Todo-Presentation")
     implementation project(':Domain-Module:Auth-Module:Auth-Presentation')
 
+    implementation project(":Domain-Module:Image-Module:Image-Infrastructure")
+
     implementation project(':Domain-Module:Auth-Module:Auth-Domain')
 
     // 임시 설정

--- a/Domain-Module/Image-Module/Image-Application/src/main/java/com/pawith/imageapplication/service/ImageDeleteUseCase.java
+++ b/Domain-Module/Image-Module/Image-Application/src/main/java/com/pawith/imageapplication/service/ImageDeleteUseCase.java
@@ -1,44 +1,9 @@
 package com.pawith.imageapplication.service;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.s3.AmazonS3;
-import com.pawith.commonmodule.annotation.ApplicationService;
-import com.pawith.commonmodule.exception.Error;
-import com.pawith.imageapplication.exception.FileDeleteException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-
 import java.util.List;
 import java.util.function.Function;
 
-@ApplicationService
-@RequiredArgsConstructor
-@Slf4j
-public class ImageDeleteUseCase<T> {
-    private final AmazonS3 amazonS3;
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
-    public void deleteImgList(List<T> imgUrlList, Function<T, String> imageUrlExtractor) {
-        if (!imgUrlList.isEmpty()) {
-            for (T img : imgUrlList) {
-                String imgUrl = imageUrlExtractor.apply(img);
-                deleteImg(imgUrl);
-            }
-        }
-    }
-
-    /*
-    개별 이미지 삭제
-    */
-    public void deleteImg(String originImgUrl) {
-        if (originImgUrl == null) return;
-        try {
-            amazonS3.deleteObject(bucket, originImgUrl.split("/")[3]);
-        } catch (AmazonServiceException e) {
-            throw new FileDeleteException(Error.FILE_DELETE_ERROR);
-        }
-    }
+public interface ImageDeleteUseCase<T> {
+    void deleteImgList(List<T> imgUrlList, Function<T, String> imageUrlExtractor);
+    public void deleteImg(String originImgUrl);
 }

--- a/Domain-Module/Image-Module/Image-Application/src/main/java/com/pawith/imageapplication/service/ImageUploadUseCase.java
+++ b/Domain-Module/Image-Module/Image-Application/src/main/java/com/pawith/imageapplication/service/ImageUploadUseCase.java
@@ -1,78 +1,14 @@
 package com.pawith.imageapplication.service;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.pawith.commonmodule.annotation.ApplicationService;
-import com.pawith.commonmodule.exception.Error;
-import com.pawith.imageapplication.exception.FileExtentionException;
-import com.pawith.imageapplication.exception.FileUploadException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.text.Normalizer;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
-@ApplicationService
-@RequiredArgsConstructor
-@Slf4j
-public class ImageUploadUseCase {
-    private final AmazonS3 amazonS3;
+public interface ImageUploadUseCase {
+    List<String> uploadImgList(List<MultipartFile> imgList);
 
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
+    CompletableFuture<String> uploadImgAsync(MultipartFile file);
 
-    public List<String> uploadImgList(List<MultipartFile> imgList) {
-
-        if(Objects.isNull(imgList)) return null;
-        if(imgList.isEmpty()) return null;
-        List<String> uploadUrl = new ArrayList<>();
-        for (MultipartFile img : imgList) {
-            uploadUrl.add(uploadImg(img));
-        }
-        return uploadUrl;
-    }
-
-
-    //단일 이미지 업로드
-    public String uploadImg(MultipartFile file) {
-        if(Objects.isNull(file)) return null;
-        if(file.isEmpty()) return null;
-
-        String originFileName = Normalizer.normalize(file.getOriginalFilename(), Normalizer.Form.NFC);
-        String fileName = createFileName(originFileName);
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentLength(file.getSize());
-        objectMetadata.setContentType(file.getContentType());
-
-        try (InputStream inputStream = file.getInputStream()) {
-            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
-                    .withCannedAcl(CannedAccessControlList.PublicRead));
-        } catch (IOException e) {
-            throw new FileUploadException(Error.FILE_UPLOAD_ERROR);
-        }
-        return amazonS3.getUrl(bucket, fileName).toString();
-    }
-
-    //파일명 난수화
-    private String createFileName(String fileName) {
-        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
-    }
-
-    //파일 확장자 체크
-    private String getFileExtension(String fileName) {
-        String ext = fileName.substring(fileName.lastIndexOf('.'));
-        if (!ext.equals(".jpg") && !ext.equals(".png") && !ext.equals(".jpeg") && !ext.equals(".svg+xml") && !ext.equals(".svg")) {
-            throw new FileExtentionException(Error.FILE_EXTENTION_ERROR);
-        }
-        return ext;
-    }
+    String uploadImg(MultipartFile file);
 }

--- a/Domain-Module/Image-Module/Image-Infrastructure/build.gradle
+++ b/Domain-Module/Image-Module/Image-Infrastructure/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(":Domain-Module:Image-Module:Image-Application")
+}

--- a/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/config/S3Config.java
+++ b/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/config/S3Config.java
@@ -1,4 +1,4 @@
-package com.pawith.imageapplication.config;
+package com.pawith.imageinfrastructure.config;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -6,6 +6,10 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.pawith.imageapplication.service.ImageDeleteUseCase;
+import com.pawith.imageapplication.service.ImageUploadUseCase;
+import com.pawith.imageinfrastructure.service.S3ImageDeleteUseCaseImpl;
+import com.pawith.imageinfrastructure.service.S3ImageUploadUseCaseImpl;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,5 +30,15 @@ public class S3Config {
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
                 .withRegion(Regions.AP_NORTHEAST_2)
                 .build();
+    }
+
+    @Bean
+    public ImageDeleteUseCase<?> imageDeleteUseCase(){
+        return new S3ImageDeleteUseCaseImpl<>(getS3ClientBean());
+    }
+
+    @Bean
+    public ImageUploadUseCase imageUploadUseCase(){
+        return new S3ImageUploadUseCaseImpl(getS3ClientBean());
     }
 }

--- a/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/exception/FileDeleteException.java
+++ b/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/exception/FileDeleteException.java
@@ -1,4 +1,4 @@
-package com.pawith.imageapplication.exception;
+package com.pawith.imageinfrastructure.exception;
 
 import com.pawith.commonmodule.exception.BusinessException;
 import com.pawith.commonmodule.exception.Error;

--- a/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/exception/FileExtentionException.java
+++ b/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/exception/FileExtentionException.java
@@ -1,4 +1,4 @@
-package com.pawith.imageapplication.exception;
+package com.pawith.imageinfrastructure.exception;
 
 import com.pawith.commonmodule.exception.BusinessException;
 import com.pawith.commonmodule.exception.Error;

--- a/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/exception/FileUploadException.java
+++ b/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/exception/FileUploadException.java
@@ -1,4 +1,4 @@
-package com.pawith.imageapplication.exception;
+package com.pawith.imageinfrastructure.exception;
 
 import com.pawith.commonmodule.exception.BusinessException;
 import com.pawith.commonmodule.exception.Error;

--- a/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/service/S3ImageDeleteUseCaseImpl.java
+++ b/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/service/S3ImageDeleteUseCaseImpl.java
@@ -1,0 +1,45 @@
+package com.pawith.imageinfrastructure.service;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.commonmodule.exception.Error;
+import com.pawith.imageinfrastructure.exception.FileDeleteException;
+import com.pawith.imageapplication.service.ImageDeleteUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.List;
+import java.util.function.Function;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Slf4j
+public class S3ImageDeleteUseCaseImpl<T> implements ImageDeleteUseCase<T> {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public void deleteImgList(List<T> imgUrlList, Function<T, String> imageUrlExtractor) {
+        if (!imgUrlList.isEmpty()) {
+            for (T img : imgUrlList) {
+                String imgUrl = imageUrlExtractor.apply(img);
+                deleteImg(imgUrl);
+            }
+        }
+    }
+
+    /*
+    개별 이미지 삭제
+    */
+    public void deleteImg(String originImgUrl) {
+        if (originImgUrl == null) return;
+        try {
+            amazonS3.deleteObject(bucket, originImgUrl.split("/")[3]);
+        } catch (AmazonServiceException e) {
+            throw new FileDeleteException(Error.FILE_DELETE_ERROR);
+        }
+    }
+}

--- a/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/service/S3ImageUploadUseCaseImpl.java
+++ b/Domain-Module/Image-Module/Image-Infrastructure/src/main/java/com/pawith/imageinfrastructure/service/S3ImageUploadUseCaseImpl.java
@@ -1,0 +1,83 @@
+package com.pawith.imageinfrastructure.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.commonmodule.exception.Error;
+import com.pawith.imageapplication.service.ImageUploadUseCase;
+import com.pawith.imageinfrastructure.exception.FileExtentionException;
+import com.pawith.imageinfrastructure.exception.FileUploadException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Slf4j
+public class S3ImageUploadUseCaseImpl implements ImageUploadUseCase {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public List<String> uploadImgList(List<MultipartFile> imgList) {
+
+        if(Objects.isNull(imgList)) return null;
+        if(imgList.isEmpty()) return null;
+        List<String> uploadUrl = new ArrayList<>();
+        for (MultipartFile img : imgList) {
+            uploadUrl.add(uploadImg(img));
+        }
+        return uploadUrl;
+    }
+
+    public CompletableFuture<String> uploadImgAsync(MultipartFile file) {
+        return CompletableFuture.supplyAsync(() -> uploadImg(file));
+    }
+
+    //단일 이미지 업로드
+    public String uploadImg(MultipartFile file) {
+        if(Objects.isNull(file)) return null;
+        if(file.isEmpty()) return null;
+
+        String originFileName = Normalizer.normalize(file.getOriginalFilename(), Normalizer.Form.NFC);
+        String fileName = createFileName(originFileName);
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(file.getContentType());
+
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new FileUploadException(Error.FILE_UPLOAD_ERROR);
+        }
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    //파일명 난수화
+    private String createFileName(String fileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    }
+
+    //파일 확장자 체크
+    private String getFileExtension(String fileName) {
+        String ext = fileName.substring(fileName.lastIndexOf('.'));
+        if (!ext.equals(".jpg") && !ext.equals(".png") && !ext.equals(".jpeg") && !ext.equals(".svg+xml") && !ext.equals(".svg")) {
+            throw new FileExtentionException(Error.FILE_EXTENTION_ERROR);
+        }
+        return ext;
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamSimpleResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamSimpleResponse.java
@@ -9,6 +9,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class TodoTeamSimpleResponse {
     private Long teamId;
+    private String teamProfileImageUrl;
     private String teamName;
     private Authority authority;
     private Integer registerPeriod;

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
@@ -31,7 +31,7 @@ public class TodoTeamGetUseCase {
             final TodoTeam todoTeam = todoTeamQueryService.findTodoTeamById(register.getTodoTeam().getId());
             final LocalDate registerDate = register.getCreatedAt().toLocalDate();
             final int registerPeriod = Period.between(registerDate, LocalDate.now()).getDays();
-            return new TodoTeamSimpleResponse(todoTeam.getId(), todoTeam.getTeamName(), register.getAuthority(), registerPeriod);
+            return new TodoTeamSimpleResponse(todoTeam.getId(), todoTeam.getTeamName(), todoTeam.getImageUrl(),register.getAuthority(), registerPeriod);
         });
         return SliceResponse.from(todoTeamSimpleResponseSlice);
     }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/TodoTeam.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/TodoTeam.java
@@ -21,9 +21,10 @@ public class TodoTeam extends BaseEntity {
 
     private String teamCode;
     private String teamName;
+    private String imageUrl;
 
-    public static TodoTeam createTodoTeam(String teamCode, String teamName) {
-        return new TodoTeam(null, teamCode, teamName);
+    public static TodoTeam createTodoTeam(String teamCode, String teamName, String imageUrl) {
+        return new TodoTeam(null, teamCode, teamName, imageUrl);
     }
 
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -72,6 +72,7 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
                 responseFields(
                     fieldWithPath("content[].teamId").description("TodoTeam의 Id"),
                     fieldWithPath("content[].teamName").description("TodoTeam의 이름"),
+                    fieldWithPath("content[].teamProfileImageUrl").description("TodoTeam의 이미지"),
                     fieldWithPath("content[].authority").description("TodoTeam의 권한"),
                     fieldWithPath("content[].registerPeriod").description("TodoTeam 가입 후 기간"),
                     fieldWithPath("page").description("요청 페이지"),

--- a/Domain-Module/User-Module/User-Application/build.gradle
+++ b/Domain-Module/User-Module/User-Application/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
     implementation project(":Domain-Module:User-Module:User-Domain")
+    implementation project(":Domain-Module:Image-Module:Image-Application")
 }

--- a/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/dto/request/UserProfileImageUpdateRequest.java
+++ b/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/dto/request/UserProfileImageUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.pawith.usermodule.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor
+public class UserProfileImageUpdateRequest {
+    private MultipartFile profileImage;
+}

--- a/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/service/UserProfileImageUpdateUseCase.java
+++ b/Domain-Module/User-Module/User-Application/src/main/java/com/pawith/usermodule/service/UserProfileImageUpdateUseCase.java
@@ -1,0 +1,44 @@
+package com.pawith.usermodule.service;
+
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.imageapplication.service.ImageUploadUseCase;
+import com.pawith.usermodule.entity.User;
+import com.pawith.usermodule.utils.UserUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class UserProfileImageUpdateUseCase {
+
+    private final ImageUploadUseCase imageUploadUseCase;
+
+    @Transactional
+    public void updateUserProfileImage(MultipartFile request) {
+//        uploadImgAsync(request);
+        final String imageUrl = imageUploadUseCase.uploadImg(request);
+        final User user = UserUtils.getAccessUser();
+        user.updateProfileImage(imageUrl);
+    }
+
+    /**
+     * 비동기로 이미지 업로드, 테스트 좀 해보고 사용할지 생각해봐야할듯
+     */
+//    private CompletableFuture<Void> uploadImgAsync(MultipartFile request) {
+//        return CompletableFuture.runAsync(() ->{
+//            transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+//                @Override
+//                protected void doInTransactionWithoutResult(TransactionStatus status) {
+//                    try {
+//                        final CompletableFuture<String> imageUploadAsync = imageUploadUseCase.uploadImgAsync(request);
+//                        final User user = UserUtils.getAccessUser();
+//                        user.updateProfileImage(imageUploadAsync.join());
+//                    }catch (Exception e) {
+//                        status.setRollbackOnly();
+//                    }
+//                }
+//            });
+//        });
+//    }
+}

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/entity/User.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/usermodule/entity/User.java
@@ -29,4 +29,10 @@ public class User extends BaseEntity {
             return;
         this.nickname = Objects.requireNonNull(nickname, "nickname must be not null");
     }
+
+    public void updateProfileImage(final String imageUrl) {
+        if(this.imageUrl.equals(imageUrl))
+            return;
+        this.imageUrl = Objects.requireNonNull(imageUrl, "imageUrl must be not null");
+    }
 }

--- a/Domain-Module/User-Module/User-Presentation/src/docs/asciidoc/User-API.adoc
+++ b/Domain-Module/User-Module/User-Presentation/src/docs/asciidoc/User-API.adoc
@@ -16,3 +16,8 @@ operation::user-controller-test/get-user-info[snippets='http-request,request-hea
 === 사용자 닉네임 변경
 
 operation::user-controller-test/put-nickname-on-user[snippets='http-request,request-fields,request-headers,http-response']
+
+[[UserController-프로필이미지변경]]
+=== 사용자 프로필 이미지 변경
+
+operation::user-controller-test/post-user-profile-image[snippets='http-request,request-headers,request-parts,http-response']

--- a/Domain-Module/User-Module/User-Presentation/src/main/java/com/pawith/userpresentation/UserController.java
+++ b/Domain-Module/User-Module/User-Presentation/src/main/java/com/pawith/userpresentation/UserController.java
@@ -1,11 +1,13 @@
 package com.pawith.userpresentation;
 
+import com.pawith.usermodule.dto.request.UserNicknameChangeRequest;
 import com.pawith.usermodule.dto.response.UserInfoResponse;
 import com.pawith.usermodule.service.UserInfoGetUseCase;
 import com.pawith.usermodule.service.UserNicknameChangeUseCase;
-import com.pawith.usermodule.dto.request.UserNicknameChangeRequest;
+import com.pawith.usermodule.service.UserProfileImageUpdateUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,6 +16,7 @@ public class UserController {
 
     private final UserNicknameChangeUseCase userNicknameChangeUseCase;
     private final UserInfoGetUseCase userInfoGetUseCase;
+    private final UserProfileImageUpdateUseCase userProfileImageUpdateUseCase;
 
     @PutMapping("/name")
     public void putNicknameOnUser(@RequestBody UserNicknameChangeRequest request){
@@ -23,5 +26,10 @@ public class UserController {
     @GetMapping
     public UserInfoResponse getUserInfo(){
         return userInfoGetUseCase.getUserInfo();
+    }
+
+    @PostMapping(consumes = "multipart/form-data")
+    public void postUserProfileImage(@RequestPart(name = "profileImage") MultipartFile request){
+        userProfileImageUpdateUseCase.updateUserProfileImage(request);
     }
 }

--- a/Domain-Module/User-Module/User-Presentation/src/test/java/com/pawith/userpresentation/UserControllerTest.java
+++ b/Domain-Module/User-Module/User-Presentation/src/test/java/com/pawith/userpresentation/UserControllerTest.java
@@ -7,19 +7,22 @@ import com.pawith.usermodule.dto.request.UserNicknameChangeRequest;
 import com.pawith.usermodule.dto.response.UserInfoResponse;
 import com.pawith.usermodule.service.UserInfoGetUseCase;
 import com.pawith.usermodule.service.UserNicknameChangeUseCase;
+import com.pawith.usermodule.service.UserProfileImageUpdateUseCase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserController.class)
@@ -30,6 +33,8 @@ class UserControllerTest extends BaseRestDocsTest {
     private UserNicknameChangeUseCase userNicknameChangeUseCase;
     @MockBean
     private UserInfoGetUseCase userInfoGetUseCase;
+    @MockBean
+    private UserProfileImageUpdateUseCase userProfileImageUpdateUseCase;
 
     private static final String USER_REQUEST_URL = "/user";
     private static final String ACCESS_TOKEN = "Bearer accessToken";
@@ -79,6 +84,29 @@ class UserControllerTest extends BaseRestDocsTest {
                     fieldWithPath("nickname").description("유저 닉네임"),
                     fieldWithPath("email").description("유저 이메일"),
                     fieldWithPath("profileImageUrl").description("유저 프로필 이미지")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("유저 프로필 이미지 업데이트 테스트")
+    void postUserProfileImage() throws Exception {
+        //given
+        final MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profileImage".getBytes());
+        final MockHttpServletRequestBuilder request = multipart(USER_REQUEST_URL)
+            .file(profileImage)
+            .contentType("multipart/form-data")
+            .header(AUTHORIZATION_HEADER, ACCESS_TOKEN);
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+            .andDo(resultHandler.document(
+                requestHeaders(
+                    headerWithName(AUTHORIZATION_HEADER).description("access 토큰")
+                ),
+                requestParts(
+                    partWithName("profileImage").description("유저 프로필 이미지")
                 )
             ));
     }

--- a/Log-Module/Log-Aop/src/main/java/com/pawith/log/aop/LogTrace.java
+++ b/Log-Module/Log-Aop/src/main/java/com/pawith/log/aop/LogTrace.java
@@ -19,6 +19,8 @@ public class LogTrace {
 
     private final ObjectMapper objectMapper;
 
+    private static final String THREAD_ID_REMOVE_END_POINT = "Controller";
+
 
     public TraceStatus start(String fullClassName, String method) {
         syncTrace();
@@ -26,7 +28,7 @@ public class LogTrace {
         long startTime = System.currentTimeMillis();
         int lastDotIndex = fullClassName.lastIndexOf(".");
         String className = fullClassName.substring(lastDotIndex + 1);
-        return new TraceStatus(id, startTime, className, method);
+        return new TraceStatus(id, startTime, className, method, className.contains(THREAD_ID_REMOVE_END_POINT));
     }
 
     @SneakyThrows
@@ -38,6 +40,7 @@ public class LogTrace {
         } else {
             logger.info(log);
         }
+        clearTheadId(traceStatus);
     }
 
     @SneakyThrows
@@ -45,12 +48,19 @@ public class LogTrace {
         final LogFormat errorLogFormat = LogFormat.createErrorLogFormat(traceStatus, exception);
         final String errorLog = objectMapper.writeValueAsString(errorLogFormat);
         logger.error(errorLog);
+        clearTheadId(traceStatus);
     }
 
     private void syncTrace() {
         String id = threadId.get();
         if (id == null) {
             threadId.set(createThreadId());
+        }
+    }
+
+    private void clearTheadId(TraceStatus traceStatus) {
+        if(traceStatus.getIsEndPoint()){
+            threadId.remove();
         }
     }
 

--- a/Log-Module/Log-Aop/src/main/java/com/pawith/log/aop/TraceStatus.java
+++ b/Log-Module/Log-Aop/src/main/java/com/pawith/log/aop/TraceStatus.java
@@ -12,4 +12,5 @@ public class TraceStatus {
     private Long startTime;
     private String className;
     private String methodName;
+    private Boolean isEndPoint;
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,4 +26,5 @@ include 'Domain-Module:Auth-Module:Auth-Domain'
 include 'Common-Module'
 include 'Domain-Module:Image-Module'
 include 'Domain-Module:Image-Module:Image-Application'
+include 'Domain-Module:Image-Module:Image-Infrastructure'
 


### PR DESCRIPTION
## 작업사항
- (User-Module)유저 프로필 이미지 수정 API  및 명세 추가
- (Todo-Module) TodoTeam 목록 조회에서 프로필 이미지도 반환되도록 수정
- (Log-Module) ThreadId 공유 문제 수정
- (Image-Module) Image-Applicaion 모듈에 있는 이미지 업로드 구현체 Image-Infrastructure로 이동

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



