### PR TITLE
Pet 122 fix : Register 비동기 방식 조회로 인한 Connection Timeout 문제 수정

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoCreateUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoCreateUseCase.java
@@ -15,8 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ListIterator;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 @ApplicationService
 @RequiredArgsConstructor
@@ -29,15 +27,12 @@ public class TodoCreateUseCase {
     private final AssignSaveService assignSaveService;
 
     public void createTodo(TodoCreateRequest request) {
-        final ListIterator<CompletableFuture<Register>> registers = request.getRegisterIds().stream()
-            .map(registerQueryService::findRegisterByIdAsync)
-            .collect(Collectors.toList())
-            .listIterator();
         final Category category = categoryQueryService.findCategoryById(request.getCategoryId());
         Todo todo = TodoMapper.mapToTodo(request, category);
         todoSaveService.saveTodoEntity(todo);
+        ListIterator<Register> registerListIterator = registerQueryService.findAllRegisterByIds(request.getRegisterIds()).listIterator();
         request.getRegisterIds().forEach(registerId -> {
-            assignSaveService.saveAssignEntity(new Assign(todo, registers.next().join()));
+            assignSaveService.saveAssignEntity(new Assign(todo, registerListIterator.next()));
         });
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Register.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Register.java
@@ -22,7 +22,6 @@ public class Register extends BaseEntity {
     @JoinColumn(name = "todoteam_id")
     private TodoTeam todoTeam;
 
-    @JoinColumn(name = "user_id")
     private Long userId;
 
     @Builder

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,4 +20,7 @@ public interface RegisterRepository extends JpaRepository<Register, Long> {
     Boolean existsByTodoTeamIdAndUserId(Long todoTeamId, Long userId);
 
     List<Register> findAllByTodoTeamId(Long todoTeamId);
+
+    @Query("select r from Register r where r.id in :ids")
+    List<Register> findAllByIds(@Param("ids") List<Long> ids);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 @DomainService
@@ -30,8 +29,9 @@ public class RegisterQueryService {
             .orElseThrow(() -> new NotRegisterUserException(Error.NOT_REGISTER_USER));
     }
 
-    public CompletableFuture<Register> findRegisterByIdAsync(Long registerId){
-        return CompletableFuture.supplyAsync(() -> findRegisterById(registerId));
+
+    public List<Register> findAllRegisterByIds(List<Long> registerIds){
+        return registerRepository.findAllByIds(registerIds);
     }
 
     public Register findRegisterById(Long registerId){


### PR DESCRIPTION
## 작업사항
- 비동기 방식으로 동작해서 커넥션 풀이 말라버려서 동기 방식으로 수정했습니다.
- Register 엔티티에 userId 필드에 @joincolumn 제거했습니다.

## 변경로직
- 비동기 방식으로 동작해서 커넥션 풀이 말라버려서 동기 방식으로 수정했습니다.

## 참고자료
- 내용을 적어주세요.



