### PR TITLE
Pet 124 refactor : 투두 리스트 조회 API 리팩터링

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategoryInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategoryInfoResponse.java
@@ -1,0 +1,11 @@
+package com.pawith.todoapplication.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CategoryInfoResponse {
+    private Long categoryId;
+    private String categoryName;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategoryListResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategoryListResponse.java
@@ -1,0 +1,12 @@
+package com.pawith.todoapplication.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CategoryListResponse {
+    private final List<CategoryInfoResponse> categories;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterTermResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterTermResponse.java
@@ -1,0 +1,26 @@
+package com.pawith.todoapplication.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RegisterTermResponse {
+    private RegisterTerm registerTerm;
+
+    public enum RegisterTerm {
+        FIRST_WEEK,
+        SECOND_WEEK,
+        AFTER_SECOND_WEEK
+    }
+
+    public RegisterTermResponse(Integer registerTerm) {
+        if (registerTerm >= 0 && registerTerm <= 6) {
+            this.registerTerm = RegisterTerm.FIRST_WEEK;
+        } else if (registerTerm > 6 && registerTerm <= 13) {
+            this.registerTerm = RegisterTerm.SECOND_WEEK;
+        } else {
+            this.registerTerm = RegisterTerm.AFTER_SECOND_WEEK;
+        }
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoListResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoListResponse.java
@@ -11,8 +11,6 @@ import java.util.List;
 @ToString
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class TodoListResponse {
-
-    private String categoryName;
     private List<CategorySubTodoResponse> todos;
 
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/CategoryGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/CategoryGetUseCase.java
@@ -1,0 +1,28 @@
+package com.pawith.todoapplication.service;
+
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.todoapplication.dto.response.CategoryInfoResponse;
+import com.pawith.todoapplication.dto.response.CategoryListResponse;
+import com.pawith.tododomain.entity.Category;
+import com.pawith.tododomain.service.CategoryQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryGetUseCase {
+
+    private final CategoryQueryService categoryQueryService;
+
+    public CategoryListResponse getCategoryList(final Long todoTeamId) {
+        List<Category> categoryList = categoryQueryService.findCategoryListByTodoTeamIdAndStatus(todoTeamId);
+        List<CategoryInfoResponse> categorySimpleResponses = categoryList.stream()
+            .map(category -> new CategoryInfoResponse(category.getId(), category.getName()))
+            .collect(Collectors.toList());
+        return new CategoryListResponse(categorySimpleResponses);
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
@@ -3,6 +3,7 @@ package com.pawith.todoapplication.service;
 import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.todoapplication.dto.response.RegisterListResponse;
 import com.pawith.todoapplication.dto.response.RegisterSimpleInfoResponse;
+import com.pawith.todoapplication.dto.response.RegisterTermResponse;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.service.RegisterQueryService;
 import com.pawith.userdomain.entity.User;
@@ -36,5 +37,11 @@ public class RegistersGetUseCase {
             })
             .collect(Collectors.toList());
         return new RegisterListResponse(registerSimpleInfoResponses);
+    }
+
+    public RegisterTermResponse getRegisterTerm(final Long teamId) {
+        final User user = userUtils.getAccessUser();
+        final Integer registerTerm = registerQueryService.findUserRegisterTerm(teamId, user.getId());
+        return new RegisterTermResponse(registerTerm);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -5,6 +5,7 @@ import com.pawith.commonmodule.slice.SliceResponse;
 import com.pawith.todoapplication.dto.response.AssignUserInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoHomeResponse;
 import com.pawith.todoapplication.dto.response.CategorySubTodoResponse;
+import com.pawith.todoapplication.dto.response.TodoListResponse;
 import com.pawith.tododomain.entity.Assign;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.entity.Todo;
@@ -45,20 +46,20 @@ public class TodoGetUseCase {
     }
 
 
-    public List<CategorySubTodoResponse> getTodoListByCategoryId(Long categoryId, LocalDate moveDate) {
+    public TodoListResponse getTodoListByCategoryId(Long categoryId, LocalDate moveDate) {
         final Map<Long, User> userMap = userQueryService.findUserMapByIds(registerQueryService::findUserIdsByCategoryId, categoryId);
         final Map<Todo, List<Register>> groupByTodo = getTodoMap(categoryId, moveDate);
-        final ArrayList<CategorySubTodoResponse> todoMainRespons = new ArrayList<>();
+        final ArrayList<CategorySubTodoResponse> todoMainResponses = new ArrayList<>();
         for (Todo todo : groupByTodo.keySet()) {
             final List<Register> registers = groupByTodo.get(todo);
-            ArrayList<AssignUserInfoResponse> assignUserInfoRespons = new ArrayList<>();
+            ArrayList<AssignUserInfoResponse> assignUserInfoResponses = new ArrayList<>();
             for (Register register : registers) {
                 final User findUser = userMap.get(register.getUserId());
-                assignUserInfoRespons.add(new AssignUserInfoResponse(findUser.getId(), findUser.getNickname()));
+                assignUserInfoResponses.add(new AssignUserInfoResponse(findUser.getId(), findUser.getNickname()));
             }
-            todoMainRespons.add(new CategorySubTodoResponse(todo.getId(), todo.getDescription(), todo.getTodoStatus().name(), assignUserInfoRespons));
+            todoMainResponses.add(new CategorySubTodoResponse(todo.getId(), todo.getDescription(), todo.getTodoStatus().name(), assignUserInfoResponses));
         }
-        return todoMainRespons;
+        return new TodoListResponse(todoMainResponses);
     }
 
     private Map<Todo, List<Register>> getTodoMap(Long categoryId, LocalDate moveDate) {

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/CategoryGetUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/CategoryGetUseCaseTest.java
@@ -1,0 +1,47 @@
+package com.pawith.todoapplication.service;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.pawith.commonmodule.UnitTestConfig;
+import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import com.pawith.todoapplication.dto.response.CategoryListResponse;
+import com.pawith.tododomain.entity.Category;
+import com.pawith.tododomain.service.CategoryQueryService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+
+@UnitTestConfig
+@DisplayName("CategoryGetUseCase 테스트")
+public class CategoryGetUseCaseTest {
+
+    @Mock
+    private CategoryQueryService categoryQueryService;
+    private CategoryGetUseCase categoryGetUseCase;
+
+    @BeforeEach
+    void init(){
+        categoryGetUseCase = new CategoryGetUseCase(categoryQueryService);
+    }
+
+    @Test
+    @DisplayName("카테고리 조회 테스트")
+    void getCategoryList() {
+        // given
+        final Long TodoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
+        final List<Category> categoryList = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+            .giveMe(Category.class, 5);
+        given(categoryQueryService.findCategoryListByTodoTeamIdAndStatus(TodoTeamId)).willReturn(categoryList);
+        // when
+        final CategoryListResponse result = categoryGetUseCase.getCategoryList(TodoTeamId);
+        // then
+        Assertions.assertThat(result.getCategories().size()).isEqualTo(categoryList.size());
+    }
+
+
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/RegistersGetUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/RegistersGetUseCaseTest.java
@@ -1,0 +1,81 @@
+package com.pawith.todoapplication.service;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.pawith.commonmodule.UnitTestConfig;
+import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import com.pawith.todoapplication.dto.response.RegisterListResponse;
+import com.pawith.todoapplication.dto.response.RegisterTermResponse;
+import com.pawith.tododomain.entity.Register;
+import com.pawith.tododomain.service.RegisterQueryService;
+import com.pawith.userdomain.entity.User;
+import com.pawith.userdomain.service.UserQueryService;
+import com.pawith.userdomain.utils.UserUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@UnitTestConfig
+@DisplayName("RegistersGetUseCase 테스트")
+public class RegistersGetUseCaseTest {
+
+    @Mock
+    private UserUtils userUtils;
+    @Mock
+    private RegisterQueryService registerQueryService;
+    @Mock
+    private UserQueryService userQueryService;
+
+    private RegistersGetUseCase registersGetUseCase;
+
+    @BeforeEach
+    void init() {
+        registersGetUseCase = new RegistersGetUseCase(userUtils, registerQueryService, userQueryService);
+    }
+
+    @Test
+    @DisplayName("Registers 조회 테스트")
+    void getRegisters() {
+        // given
+        final User mockUser = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMeOne(User.class);
+        final User mockFindUser = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMeOne(User.class);
+        final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
+        final List<Register> registerList = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMe(Register.class, 5);
+        given(userUtils.getAccessUser()).willReturn(mockUser);
+        given(registerQueryService.findAllRegisters(mockUser.getId(), todoTeamId)).willReturn(registerList);
+        given(userQueryService.findById(any())).willReturn(mockFindUser);
+        // when
+        RegisterListResponse registerListResponse = registersGetUseCase.getRegisters(todoTeamId);
+        // then
+        Assertions.assertThat(registerListResponse).isNotNull();
+        Assertions.assertThat(registerListResponse.getRegisters().size()).isEqualTo(registerList.size());
+
+    }
+
+    @Test
+    @DisplayName("Register 기간 조회 테스트")
+    void getRegisterTerm() {
+        // given
+        final User mockUser = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMeOne(User.class);
+        final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
+        final Integer registerTerm = FixtureMonkey.create().giveMeOne(Integer.class);
+        given(userUtils.getAccessUser()).willReturn(mockUser);
+        given(registerQueryService.findUserRegisterTerm(todoTeamId, mockUser.getId())).willReturn(registerTerm);
+        // when
+        RegisterTermResponse registerTermResponse = registersGetUseCase.getRegisterTerm(todoTeamId);
+        // then
+        Assertions.assertThat(registerTermResponse).isNotNull();
+    }
+
+
+}

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/CategoryRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/CategoryRepository.java
@@ -2,9 +2,11 @@ package com.pawith.tododomain.repository;
 
 import com.pawith.tododomain.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    List<Category> findAllByTodoTeamId(Long todoTeamId);
+    @Query("select c from Category c where c.todoTeam.id = :todoTeamId and c.categoryStatus = 'ON'")
+    List<Category> findAllByTodoTeamIdAndCategoryStatus(Long todoTeamId);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/CategoryQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/CategoryQueryService.java
@@ -15,10 +15,9 @@ public class CategoryQueryService {
 
     private final CategoryRepository categoryRepository;
 
-    public List<Category> findCategoryListByTodoTeamId(Long todoTeamId) {
-        return categoryRepository.findAllByTodoTeamId(todoTeamId);
+    public List<Category> findCategoryListByTodoTeamIdAndStatus(Long todoTeamId) {
+        return categoryRepository.findAllByTodoTeamIdAndCategoryStatus(todoTeamId);
     }
-
     public Category findCategoryById(Long categoryId) {
         return categoryRepository.findById(categoryId).orElseThrow();
     }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -73,5 +75,10 @@ public class RegisterQueryService {
                                         T specificationData1, U specificationData2) {
         return method.apply(specificationData1, specificationData2)
             .orElseThrow(() -> new NotRegisterUserException(Error.NOT_REGISTER_USER));
+    }
+
+    public Integer findUserRegisterTerm (Long todoTeamId, Long userId){
+        Register register = findRegisterByTodoTeamIdAndUserId(todoTeamId, userId);
+        return (int) ChronoUnit.DAYS.between(register.getCreatedAt().toLocalDate(), LocalDate.now());
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/test/java/com/pawith/tododomain/service/CategoryQueryServiceTest.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/test/java/com/pawith/tododomain/service/CategoryQueryServiceTest.java
@@ -35,9 +35,9 @@ class CategoryQueryServiceTest {
         //given
         final Long mockTodoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
         final List<Category> mockCategoryList = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(Category.class, 10);
-        given(categoryRepository.findAllByTodoTeamId(mockTodoTeamId)).willReturn(mockCategoryList);
+        given(categoryRepository.findAllByTodoTeamIdAndCategoryStatus(mockTodoTeamId)).willReturn(mockCategoryList);
         //when
-        List<Category> result = categoryQueryService.findCategoryListByTodoTeamId(mockTodoTeamId);
+        List<Category> result = categoryQueryService.findCategoryListByTodoTeamIdAndStatus(mockTodoTeamId);
         //then
         Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(mockCategoryList);
     }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/test/java/com/pawith/tododomain/service/RegisterQueryServiceTest.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/test/java/com/pawith/tododomain/service/RegisterQueryServiceTest.java
@@ -16,8 +16,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.mockito.BDDMockito.given;
 
@@ -169,5 +172,32 @@ class RegisterQueryServiceTest {
         Assertions.assertThat(result).isEqualTo(mockCount);
     }
 
+    @Test
+    @DisplayName("CategoryId로 UserId를 조회한다.")
+    void findUserIdsByCategoryId() {
+        //given
+        final Long categoryId = FixtureMonkey.create().giveMeOne(Long.class);
+        final List<Register> mockRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(Register.class, 10);
+        given(registerRepository.findAllByCategoryId(categoryId)).willReturn(mockRegister);
+        //when
+        List<Long> result = registerQueryService.findUserIdsByCategoryId(categoryId);
+        //then
+        Assertions.assertThat(result).isEqualTo(mockRegister.stream().map(Register::getUserId).collect(Collectors.toList()));
+    }
+
+    @Test
+    @DisplayName("todoTeam 가입 기간을 조회한다")
+    void findUserRegisterTerm() {
+        //given
+        final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
+        final Long userId = FixtureMonkey.create().giveMeOne(Long.class);
+        final Register mockRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(Register.class);
+        final LocalDate mockDate = LocalDate.now();
+        given(registerRepository.findByTodoTeamIdAndUserId(todoTeamId, userId)).willReturn(Optional.of(mockRegister));
+        //when
+        Integer result = registerQueryService.findUserRegisterTerm(todoTeamId, userId);
+        //then
+        Assertions.assertThat(result).isEqualTo((int) ChronoUnit.DAYS.between(mockRegister.getCreatedAt().toLocalDate(), mockDate));
+    }
 
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -58,7 +58,12 @@ operation::todo-controller-test/get-todo-progress[snippets='http-request,path-pa
 operation::todo-controller-test/post-todo[snippets='http-request,request-fields,request-headers,http-response']
 
 [[Todo-API-투두-리스트-조회]]
-=== Todo 생성
+=== Todo 카테고리 리스트 조회
+
+operation::category-controller-test/get-category-list[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
+[[Todo-API-투두-리스트-조회]]
+=== Todo 투두 리스트 조회
 
 operation::todo-controller-test/get-todo-list[snippets='http-request,path-parameters,request-headers,request-parameters,http-response,response-fields']
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -71,3 +71,8 @@ operation::todo-controller-test/get-todo-list[snippets='http-request,path-parame
 === Todo 주차 달성률 비교
 
 operation::todo-controller-test/get-week-progress-compare[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
+[[Todo-API-투두-팀-가입-기간-조회]]
+=== Todo 팀 가입 기간 조회
+
+operation::todo-controller-test/get-register-term[snippets='http-request,path-parameters,request-headers,http-response,response-fields']

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/CategoryController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/CategoryController.java
@@ -1,0 +1,24 @@
+package com.pawith.todopresentation;
+
+import com.pawith.todoapplication.dto.response.CategoryListResponse;
+import com.pawith.todoapplication.service.CategoryGetUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/category")
+public class CategoryController {
+
+    private final CategoryGetUseCase categoryGetUseCase;
+
+    @GetMapping("/{teamId}")
+    public CategoryListResponse getCategoryList(@PathVariable Long teamId){
+        return categoryGetUseCase.getCategoryList(teamId);
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
@@ -3,6 +3,7 @@ package com.pawith.todopresentation;
 import com.pawith.commonmodule.slice.SliceResponse;
 import com.pawith.todoapplication.dto.request.TodoCreateRequest;
 import com.pawith.todoapplication.dto.response.*;
+import com.pawith.todoapplication.service.RegistersGetUseCase;
 import com.pawith.todoapplication.service.TodoCreateUseCase;
 import com.pawith.todoapplication.service.TodoGetUseCase;
 import com.pawith.todoapplication.service.TodoRateGetUseCase;
@@ -23,6 +24,7 @@ public class TodoController {
     private final TodoGetUseCase todoGetUseCase;
     private final TodoRateGetUseCase todoRateGetUseCase;
     private final TodoCreateUseCase todoCreateUseCase;
+    private final RegistersGetUseCase registersGetUseCase;
 
     /**
      * 리팩터링 전 : 동시 100명 요청 평균 426ms
@@ -56,6 +58,11 @@ public class TodoController {
     @GetMapping("/compare/{teamId}")
     public TodoRateCompareResponse getWeekProgressCompare(@PathVariable Long teamId){
         return todoRateGetUseCase.getWeekProgressCompare(teamId);
+    }
+
+    @GetMapping("/register/{teamId}")
+    public RegisterTermResponse getRegisterTerm(@PathVariable Long teamId){
+        return registersGetUseCase.getRegisterTerm(teamId);
     }
 
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
@@ -48,9 +48,9 @@ public class TodoController {
     }
 
 
-    @GetMapping("/{teamId}")
-    public List<CategorySubTodoResponse> getTodoList(@PathVariable Long teamId, @RequestParam("moveDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)  LocalDate moveDate){
-        return todoGetUseCase.getTodoListByCategoryId(teamId, moveDate);
+    @GetMapping("/{categoryId}")
+    public TodoListResponse getTodoList(@PathVariable Long categoryId, @RequestParam("moveDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)  LocalDate moveDate){
+        return todoGetUseCase.getTodoListByCategoryId(categoryId, moveDate);
     }
 
     @GetMapping("/compare/{teamId}")

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/CategoryControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/CategoryControllerTest.java
@@ -1,0 +1,66 @@
+package com.pawith.todopresentation;
+
+import com.pawith.commonmodule.BaseRestDocsTest;
+import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import com.pawith.todoapplication.dto.response.CategoryInfoResponse;
+import com.pawith.todoapplication.dto.response.CategoryListResponse;
+import com.pawith.todoapplication.service.CategoryGetUseCase;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@WebMvcTest(CategoryController.class)
+@DisplayName("CategoryController 테스트")
+public class CategoryControllerTest extends BaseRestDocsTest {
+
+    @MockBean
+    private CategoryGetUseCase categoryGetUseCase;
+
+    private static final String CATEGORY_REQUEST_URL = "/category";
+
+    @Test
+    @DisplayName("카테고리 조회 테스트")
+    public void getCategoryList() throws Exception {
+        // given
+        final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
+        final List<CategoryInfoResponse> categoryListResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(CategoryInfoResponse.class, 2);
+        final CategoryListResponse categoryListResponse = new CategoryListResponse(categoryListResponses);
+        given(categoryGetUseCase.getCategoryList(testTeamId)).willReturn(categoryListResponse);
+        MockHttpServletRequestBuilder request = get(CATEGORY_REQUEST_URL + "/{teamId}", testTeamId)
+                .header("Authorization", "Bearer accessToken");
+        // when
+        ResultActions result = mvc.perform(request);
+        // then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("TodoTeam의 Id")
+                        ),
+                        responseFields(
+                                fieldWithPath("categories[].categoryId").description("Category의 Id"),
+                                fieldWithPath("categories[].categoryName").description("Category의 이름")
+                        )
+                ));
+    }
+
+}

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -143,53 +144,48 @@ public class TodoControllerTest extends BaseRestDocsTest {
             ));
     }
 
-//    @Test
-//    @DisplayName("투두 리스트 조회 API 테스트")
-//    void getTodoList() throws Exception{
-//        //given
-//        final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
-//        final LocalDate testMoveDate = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(LocalDate.class);
-//        final List<AssignSimpleInfoResponse> assignSimpleInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(AssignSimpleInfoResponse.class, 2);
-//        final List<TodoSimpleResponse> todoSimpleResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
-//            .giveMeBuilder(TodoSimpleResponse.class)
-//            .set("todoId", Arbitraries.longs().greaterOrEqual(1L))
-//            .set("task", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(5).ofMaxLength(10))
-//            .set("status", FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeBuilder("COMPLETE"))
-//            .set("assignNames", assignSimpleInfoResponses)
-//            .sampleList(2);
-//        final List<TodoListResponse> todoListResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
-//                .giveMeBuilder(TodoListResponse.class)
-//                .set("categoryName", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(5).ofMaxLength(10))
-//                .set("todos", todoSimpleResponses)
-//                .sampleList(2);
-//        given(todoGetUseCase.getTodoList(any(), any())).willReturn(todoListResponses);
-//        MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/{teamId}", testTeamId)
-//                .queryParam("moveDate", testMoveDate.toString())
-//                .header("Authorization", "Bearer accessToken");
-//        //when
-//        ResultActions result = mvc.perform(request);
-//        //then
-//        result.andExpect(status().isOk())
-//                .andDo(resultHandler.document(
-//                        requestHeaders(
-//                                headerWithName("Authorization").description("access 토큰")
-//                        ),
-//                        pathParameters(
-//                                parameterWithName("teamId").description("TodoTeam의 Id")
-//                        ),
-//                        requestParameters(
-//                                parameterWithName("moveDate").description("달력에서 이동하는 날짜(LocalDate)")
-//                        ),
-//                        responseFields(
-//                                fieldWithPath("[].categoryName").description("카테고리 이름"),
-//                                fieldWithPath("[].todos[].todoId").description("투두 항목 Id"),
-//                                fieldWithPath("[].todos[].task").description("투두 항목 이름"),
-//                                fieldWithPath("[].todos[].status").description("투두 항목 상태(완료, 미완료)"),
-//                                fieldWithPath("[].todos[].assignNames[].assigneeId").description("할당받은 사용자의 ID"),
-//                                fieldWithPath("[].todos[].assignNames[].assigneeName").description("할당받은 사용자의 이름")
-//                        )
-//                ));
-//    }
+    @Test
+    @DisplayName("투두 리스트 조회 API 테스트")
+    void getTodoList() throws Exception{
+        //given
+        final Long testCategoryId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
+        final LocalDate testMoveDate = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(LocalDate.class);
+        final List<AssignUserInfoResponse> assignUserInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(AssignUserInfoResponse.class, 2);
+        final List<CategorySubTodoResponse> categorySubTodoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
+            .giveMeBuilder(CategorySubTodoResponse.class)
+            .set("todoId", Arbitraries.longs().greaterOrEqual(1L))
+            .set("task", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(5).ofMaxLength(10))
+            .set("status", FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeBuilder("COMPLETE"))
+            .set("assignNames", assignUserInfoResponses)
+            .sampleList(2);
+        final TodoListResponse todoListResponse = new TodoListResponse(categorySubTodoResponses);
+        given(todoGetUseCase.getTodoListByCategoryId(any(), any())).willReturn(todoListResponse);
+        MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/{categoryId}", testCategoryId)
+                .queryParam("moveDate", testMoveDate.toString())
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("categoryId").description("Category의 Id")
+                        ),
+                        requestParameters(
+                                parameterWithName("moveDate").description("달력에서 이동하는 날짜(LocalDate)")
+                        ),
+                        responseFields(
+                                fieldWithPath("todos[].todoId").description("투두 항목 Id"),
+                                fieldWithPath("todos[].task").description("투두 항목 이름"),
+                                fieldWithPath("todos[].status").description("투두 항목 상태(완료, 미완료)"),
+                                fieldWithPath("todos[].assignNames[].assigneeId").description("할당받은 사용자의 ID"),
+                                fieldWithPath("todos[].assignNames[].assigneeName").description("할당받은 사용자의 이름")
+                        )
+                ));
+    }
 
 
     @Test

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -4,9 +4,8 @@ import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.commonmodule.slice.SliceResponse;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
 import com.pawith.todoapplication.dto.request.TodoCreateRequest;
-import com.pawith.todoapplication.dto.response.TodoHomeResponse;
-import com.pawith.todoapplication.dto.response.TodoProgressResponse;
-import com.pawith.todoapplication.dto.response.TodoRateCompareResponse;
+import com.pawith.todoapplication.dto.response.*;
+import com.pawith.todoapplication.service.RegistersGetUseCase;
 import com.pawith.todoapplication.service.TodoCreateUseCase;
 import com.pawith.todoapplication.service.TodoGetUseCase;
 import com.pawith.todoapplication.service.TodoRateGetUseCase;
@@ -45,6 +44,8 @@ public class TodoControllerTest extends BaseRestDocsTest {
     private TodoGetUseCase todoGetUseCase;
     @MockBean
     private TodoCreateUseCase todoCreateUseCase;
+    @MockBean
+    private RegistersGetUseCase registersGetUseCase;
 
     private static final String TODO_REQUEST_URL = "/todo";
 
@@ -209,6 +210,33 @@ public class TodoControllerTest extends BaseRestDocsTest {
                         ),
                         responseFields(
                                 fieldWithPath("compareWithLastWeek").description("지난주 달성률과 이번주 달성률 비교. HIGER : 지난주보다 높음, LOWER : 지난주보다 낮음, SAME : 지난주와 같음")
+                        )
+                ));
+    }
+
+
+    @Test
+    @DisplayName("팀 가입 기간 조회 API 테스트")
+    void getRegisterTerm() throws Exception {
+        //given
+        final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
+        final RegisterTermResponse registerTermResponse = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(RegisterTermResponse.class);
+        given(registersGetUseCase.getRegisterTerm(testTeamId)).willReturn(registerTermResponse);
+        MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/register/{teamId}", testTeamId)
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("TodoTeam의 Id")
+                        ),
+                        responseFields(
+                                fieldWithPath("registerTerm").description("팀 가입 한 기간. FIRST_WEEK : 1주, SECOND_WEEK : 2주, AFTER_SECOND_WEEK : 2주 이상")
                         )
                 ));
     }


### PR DESCRIPTION
## 작업사항
- 투두 리스트 조회 API 리팩터링 
  - TodoController의 getTodoList 메서드 PathVariable teamId -> categoryId로 수정
  - List 반환 대신 Dto로 감싸서 반환하게 수정, 오타 수정
  - API 테스트 코드 수정
  - 관련 domain 테스트 코드 작성 (RegisterQueryServiceTest.findUserIdsByCategoryId)
- 투두 리스트 조회를 카테고리 조회 / 투두 + 담당자 조회로 분리하면서 카테고리 조회 API 추가
  - 카테고리 조회 API 테스트 코드 작성, 명세 추가 
  - 카테고리 조회 관련 application, domain 테스트 코드 작성
- TodoTeam 가입 기간 조회 API 추가, 테스트 코드 작성, 명세 추가
- TodoTeam 가입 기간 조회 관련 application, domain 테스트 코드 작성 

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



