### PR TITLE
Pet 137 feat : RefreshToken 재발급시 미사용 토큰 삭제 이벤트 메소드 추가

### DIFF
--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/handler/UnusedTokenExpireEventHandler.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/handler/UnusedTokenExpireEventHandler.java
@@ -1,0 +1,28 @@
+package com.pawith.authapplication.handler;
+
+import com.pawith.authapplication.handler.request.UnusedTokenExpireEvent;
+import com.pawith.authdomain.entity.Token;
+import com.pawith.authdomain.service.TokenDeleteService;
+import com.pawith.authdomain.service.TokenQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class UnusedTokenExpireEventHandler {
+
+    private final TokenQueryService tokenQueryService;
+    private final TokenDeleteService tokenDeleteService;
+
+    @EventListener
+    public void handle(UnusedTokenExpireEvent event){
+        final List<Token> allToken = tokenQueryService.findAllByEmailAndTokenType(event.getEmail(), event.getTokenType());
+        tokenDeleteService.deleteAllToken(allToken);
+    }
+
+}

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/handler/request/UnusedTokenExpireEvent.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/handler/request/UnusedTokenExpireEvent.java
@@ -1,0 +1,12 @@
+package com.pawith.authapplication.handler.request;
+
+import com.pawith.authdomain.jwt.TokenType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UnusedTokenExpireEvent {
+    private final String email;
+    private final TokenType tokenType;
+}

--- a/Domain-Module/Auth-Module/Auth-Application/src/test/java/com/pawith/authapplication/service/command/OAuthInvokerTest.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/test/java/com/pawith/authapplication/service/command/OAuthInvokerTest.java
@@ -53,8 +53,6 @@ class OAuthInvokerTest {
         final OAuthUserInfo mockOAuthUserInfo = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(OAuthUserInfo.class);
         final String accessToken = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(String.class);
         final String refreshToken = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(String.class);
-        log.info("accessToken: {}", accessToken);
-        log.info("refreshToken: {}", refreshToken);
         given(authHandler.isAccessible(mockRequest)).willReturn(true);
         given(authHandler.handle(mockRequest)).willReturn(mockOAuthUserInfo);
         given(jwtProvider.generateAccessToken(mockOAuthUserInfo.getEmail())).willReturn(accessToken);

--- a/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/repository/TokenRepository.java
+++ b/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/repository/TokenRepository.java
@@ -4,8 +4,11 @@ import com.pawith.authdomain.entity.Token;
 import com.pawith.authdomain.jwt.TokenType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
-    Optional<Token> findByValueAndTokenType(String email, TokenType tokenType);;
+    Optional<Token> findByValueAndTokenType(String email, TokenType tokenType);
+
+    List<Token> findAllByEmailAndTokenType(String email, TokenType tokenType);
 }

--- a/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/TokenDeleteService.java
+++ b/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/TokenDeleteService.java
@@ -2,7 +2,11 @@ package com.pawith.authdomain.service;
 
 import com.pawith.authdomain.entity.Token;
 
+import java.util.List;
+
 public interface TokenDeleteService {
 
     void deleteRefreshToken(final Token token);
+
+    void deleteAllToken(final List<Token> tokenList);
 }

--- a/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/TokenQueryService.java
+++ b/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/TokenQueryService.java
@@ -3,9 +3,13 @@ package com.pawith.authdomain.service;
 import com.pawith.authdomain.entity.Token;
 import com.pawith.authdomain.jwt.TokenType;
 
+import java.util.List;
+
 public interface TokenQueryService {
 
     String findEmailByValue(final String value, final TokenType tokenType);
 
     Token findTokenByValue(final String value, final TokenType tokenType);
+
+    List<Token> findAllByEmailAndTokenType(String email, TokenType tokenType);
 }

--- a/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/impl/TokenDeleteServiceImpl.java
+++ b/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/impl/TokenDeleteServiceImpl.java
@@ -7,6 +7,8 @@ import com.pawith.commonmodule.annotation.DomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @DomainService
 @RequiredArgsConstructor
 @Transactional
@@ -16,5 +18,9 @@ public class TokenDeleteServiceImpl implements TokenDeleteService {
 
     public void deleteRefreshToken(final Token token){
         tokenRepository.delete(token);
+    }
+
+    public void deleteAllToken(final List<Token> tokenList){
+        tokenRepository.deleteAll(tokenList);
     }
 }

--- a/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/impl/TokenQueryServiceImpl.java
+++ b/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/impl/TokenQueryServiceImpl.java
@@ -1,13 +1,15 @@
 package com.pawith.authdomain.service.impl;
 
-import com.pawith.commonmodule.annotation.DomainService;
-import com.pawith.commonmodule.exception.Error;
 import com.pawith.authdomain.entity.Token;
 import com.pawith.authdomain.exception.NotExistTokenException;
+import com.pawith.authdomain.jwt.TokenType;
 import com.pawith.authdomain.repository.TokenRepository;
 import com.pawith.authdomain.service.TokenQueryService;
-import com.pawith.authdomain.jwt.TokenType;
+import com.pawith.commonmodule.annotation.DomainService;
+import com.pawith.commonmodule.exception.Error;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @DomainService
 @RequiredArgsConstructor
@@ -22,6 +24,10 @@ public class TokenQueryServiceImpl implements TokenQueryService {
     @Override
     public Token findTokenByValue(String value, TokenType tokenType) {
         return findToken(value, tokenType);
+    }
+
+    public List<Token> findAllByEmailAndTokenType(String email, TokenType tokenType){
+        return tokenRepository.findAllByEmailAndTokenType(email, tokenType);
     }
 
     private Token findToken(final String value, final TokenType tokenType){


### PR DESCRIPTION
## 작업사항
- RefreshToken 재발급시 미사용 토큰 삭제 이벤트 메소드 추가

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 모듈간 이벤트가 아닌 모듈 내부에서 발생하는 이벤트여서 Auth-Application 모듈 내부에 이벤트 클래스 위치했습니다~



