### PR TITLE
Pet 126 feat : 토큰 재발급 API 추가

### DIFF
--- a/Common-Module/src/testFixtures/java/com/pawith/commonmodule/utils/FixtureMonkeyUtils.java
+++ b/Common-Module/src/testFixtures/java/com/pawith/commonmodule/utils/FixtureMonkeyUtils.java
@@ -1,9 +1,11 @@
 package com.pawith.commonmodule.utils;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.generator.JavaDefaultArbitraryGeneratorBuilder;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.arbitraries.StringArbitrary;
 
 public class FixtureMonkeyUtils {
     private FixtureMonkeyUtils() {
@@ -25,7 +27,12 @@ public class FixtureMonkeyUtils {
         .build();
 
     private static final FixtureMonkey JAVA_TYPE_BASED_FIXTURE_MONKEY = FixtureMonkey.builder()
-        .objectIntrospector(JavaDefaultArbitraryGeneratorBuilder.JAVA_INTROSPECTOR)
+        .javaTypeArbitraryGenerator(new JavaTypeArbitraryGenerator() {
+            @Override
+            public StringArbitrary strings() {
+                return Arbitraries.strings().alpha().numeric().ofMinLength(1).ofMaxLength(10);
+            }
+        })
         .defaultNotNull(true)
         .build();
 

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/consts/AuthConsts.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/consts/AuthConsts.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthConsts {
     public static final String AUTHENTICATION_TYPE= "Bearer";
+    public static final String AUTHENTICATION_TYPE_PREFIX = "Bearer ";
     public static final String AUTHORIZATION = "Authorization";
     public static final String REFRESH_TOKEN_HEADER = "RefreshToken";
     public static final String EMPTY_HEADER = null;

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/consts/AuthConsts.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/consts/AuthConsts.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthConsts {
     public static final String AUTHENTICATION_TYPE= "Bearer";
-    public static final String AUTHENTICATION_TYPE_PREFIX = "Bearer ";
+    public static final String AUTHENTICATION_TYPE_PREFIX = AUTHENTICATION_TYPE+" ";
     public static final String AUTHORIZATION = "Authorization";
     public static final String REFRESH_TOKEN_HEADER = "RefreshToken";
     public static final String EMPTY_HEADER = null;

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/consts/IgnoredPathConsts.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/consts/IgnoredPathConsts.java
@@ -15,6 +15,7 @@ public class IgnoredPathConsts {
         "/docs/**", HttpMethod.GET,
         "/oauth/**", HttpMethod.GET,
         "/jwt", HttpMethod.GET,
+        "/reissue",HttpMethod.POST,
         "/actuator/**", HttpMethod.GET
     );
 

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/consts/IgnoredPathConsts.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/consts/IgnoredPathConsts.java
@@ -13,6 +13,7 @@ public class IgnoredPathConsts {
     @Getter
     private static Map<String, HttpMethod> ignoredPath = Map.of(
         "/docs/**", HttpMethod.GET,
+        "/favicon.ico", HttpMethod.GET,
         "/oauth/**", HttpMethod.GET,
         "/jwt", HttpMethod.GET,
         "/reissue",HttpMethod.POST,

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/dto/TokenReissueResponse.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/dto/TokenReissueResponse.java
@@ -1,0 +1,13 @@
+package com.pawith.authapplication.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@AllArgsConstructor
+public class TokenReissueResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/ReissueUseCase.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/ReissueUseCase.java
@@ -1,0 +1,7 @@
+package com.pawith.authapplication.service;
+
+import com.pawith.authapplication.dto.TokenReissueResponse;
+
+public interface ReissueUseCase {
+    TokenReissueResponse reissue(String refreshToken);
+}

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/command/OAuthInvoker.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/command/OAuthInvoker.java
@@ -24,9 +24,6 @@ public class OAuthInvoker {
     private final List<AuthHandler> authHandlerList;
     private final JWTProvider jwtProvider;
     private final ApplicationEventPublisher publisher;
-
-    private static final String AUTHENTICATION_TYPE = AuthConsts.AUTHENTICATION_TYPE + " ";
-
     public OAuthResponse execute(OAuthRequest request){
         OAuthUserInfo oAuthUserInfo = attemptLogin(request);
         publishEvent(request, oAuthUserInfo);
@@ -57,6 +54,6 @@ public class OAuthInvoker {
     }
 
     private <T> String attachAuthenticationType(Function<T, String> generateTokenMethod, T includeClaimData) {
-        return AUTHENTICATION_TYPE + generateTokenMethod.apply(includeClaimData);
+        return AuthConsts.AUTHENTICATION_TYPE_PREFIX + generateTokenMethod.apply(includeClaimData);
     }
 }

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/JWTExtractEmailUseCaseImpl.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/JWTExtractEmailUseCaseImpl.java
@@ -2,10 +2,10 @@ package com.pawith.authapplication.service.impl;
 
 import com.pawith.authapplication.service.JWTExtractEmailUseCase;
 import com.pawith.authdomain.jwt.JWTProvider;
+import com.pawith.commonmodule.annotation.ApplicationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-@Service
+@ApplicationService
 @RequiredArgsConstructor
 public class JWTExtractEmailUseCaseImpl implements JWTExtractEmailUseCase {
     private final JWTProvider jwtProvider;

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/JWTExtractTokenUseCaseImpl.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/JWTExtractTokenUseCaseImpl.java
@@ -2,11 +2,11 @@ package com.pawith.authapplication.service.impl;
 
 import com.pawith.authapplication.service.JWTExtractTokenUseCase;
 import com.pawith.authapplication.utils.TokenExtractUtils;
+import com.pawith.commonmodule.annotation.ApplicationService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 @Slf4j
-@Service
+@ApplicationService
 public class JWTExtractTokenUseCaseImpl implements JWTExtractTokenUseCase {
     @Override
     public String extractToken(final String tokenHeader) {

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/JWTVerifyUseCaseImpl.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/JWTVerifyUseCaseImpl.java
@@ -2,10 +2,10 @@ package com.pawith.authapplication.service.impl;
 
 import com.pawith.authapplication.service.JWTVerifyUseCase;
 import com.pawith.authdomain.jwt.JWTProvider;
+import com.pawith.commonmodule.annotation.ApplicationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-@Service
+@ApplicationService
 @RequiredArgsConstructor
 public class JWTVerifyUseCaseImpl implements JWTVerifyUseCase {
     private final JWTProvider jwtProvider;

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/LogoutUseCaseImpl.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/LogoutUseCaseImpl.java
@@ -24,6 +24,6 @@ public class LogoutUseCaseImpl implements LogoutUseCase {
     public void logoutAccessUser(String refreshTokenHeader) {
         final String refreshToken = TokenExtractUtils.extractToken(refreshTokenHeader);
         final Token refreshTokenEntity = tokenQueryService.findTokenByValue(refreshToken, TokenType.REFRESH_TOKEN);
-        tokenDeleteService.deleteRefreshToken(refreshTokenEntity);
+        tokenDeleteService.deleteToken(refreshTokenEntity);
     }
 }

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/OAuthUseCaseImpl.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/OAuthUseCaseImpl.java
@@ -1,14 +1,14 @@
 package com.pawith.authapplication.service.impl;
 
-import com.pawith.authapplication.service.OAuthUseCase;
 import com.pawith.authapplication.dto.OAuthRequest;
 import com.pawith.authapplication.dto.OAuthResponse;
-import com.pawith.commonmodule.enums.Provider;
+import com.pawith.authapplication.service.OAuthUseCase;
 import com.pawith.authapplication.service.command.OAuthInvoker;
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.commonmodule.enums.Provider;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-@Service
+@ApplicationService
 @RequiredArgsConstructor
 public class OAuthUseCaseImpl implements OAuthUseCase {
 

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/ReissueUseCaseImpl.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/impl/ReissueUseCaseImpl.java
@@ -1,0 +1,27 @@
+package com.pawith.authapplication.service.impl;
+
+import com.pawith.authapplication.consts.AuthConsts;
+import com.pawith.authapplication.dto.TokenReissueResponse;
+import com.pawith.authapplication.service.ReissueUseCase;
+import com.pawith.authapplication.utils.TokenExtractUtils;
+import com.pawith.authdomain.jwt.JWTProvider;
+import com.pawith.authdomain.service.TokenDeleteService;
+import com.pawith.commonmodule.annotation.ApplicationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@ApplicationService
+public class ReissueUseCaseImpl implements ReissueUseCase {
+    private final JWTProvider jwtProvider;
+    private final TokenDeleteService tokenDeleteService;
+    @Override
+    public TokenReissueResponse reissue(String refreshTokenHeader) {
+        final String refreshToken = TokenExtractUtils.extractToken(refreshTokenHeader);
+        final String reissueAccessToken = AuthConsts.AUTHENTICATION_TYPE_PREFIX+jwtProvider.reIssueAccessToken(refreshToken);
+        final String reissueRefreshToken = AuthConsts.AUTHENTICATION_TYPE_PREFIX+jwtProvider.reIssueRefreshToken(refreshToken);
+        tokenDeleteService.deleteTokenByValue(refreshToken);
+        return new TokenReissueResponse(reissueAccessToken, reissueRefreshToken);
+    }
+}

--- a/Domain-Module/Auth-Module/Auth-Application/src/test/java/com/pawith/authapplication/service/LogoutUseCaseImplTest.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/test/java/com/pawith/authapplication/service/LogoutUseCaseImplTest.java
@@ -37,7 +37,7 @@ class LogoutUseCaseImplTest {
     void logoutAccessUser() {
         // given
         final String refreshToken = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(String.class);
-        final String refreshTokenHeader = AuthConsts.AUTHENTICATION_TYPE + " " + refreshToken;
+        final String refreshTokenHeader = AuthConsts.AUTHENTICATION_TYPE_PREFIX+ refreshToken;
         final Token mockToken = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeBuilder(Token.class)
             .set("value", refreshToken)
             .sample();
@@ -45,6 +45,6 @@ class LogoutUseCaseImplTest {
         // when
         logoutUseCase.logoutAccessUser(refreshTokenHeader);
         // then
-        then(tokenDeleteService).should().deleteRefreshToken(mockToken);
+        then(tokenDeleteService).should().deleteToken(mockToken);
     }
 }

--- a/Domain-Module/Auth-Module/Auth-Application/src/test/java/com/pawith/authapplication/service/command/OAuthInvokerTest.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/test/java/com/pawith/authapplication/service/command/OAuthInvokerTest.java
@@ -62,6 +62,8 @@ class OAuthInvokerTest {
         // then
         Assertions.assertThat(result.getAccessToken()).startsWith(AuthConsts.AUTHENTICATION_TYPE);
         Assertions.assertThat(result.getRefreshToken()).startsWith(AuthConsts.AUTHENTICATION_TYPE);
+        Assertions.assertThat(result.getAccessToken()).startsWith(AuthConsts.AUTHENTICATION_TYPE_PREFIX);
+        Assertions.assertThat(result.getRefreshToken()).startsWith(AuthConsts.AUTHENTICATION_TYPE_PREFIX);
         Assertions.assertThat(TokenExtractUtils.extractToken(result.getAccessToken())).isEqualTo(accessToken);
         Assertions.assertThat(TokenExtractUtils.extractToken(result.getRefreshToken())).isEqualTo(refreshToken);
     }

--- a/Domain-Module/Auth-Module/Auth-Application/src/test/java/com/pawith/authapplication/service/impl/ReissueUseCaseImplTest.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/test/java/com/pawith/authapplication/service/impl/ReissueUseCaseImplTest.java
@@ -1,0 +1,50 @@
+package com.pawith.authapplication.service.impl;
+
+import com.pawith.authapplication.consts.AuthConsts;
+import com.pawith.authapplication.dto.TokenReissueResponse;
+import com.pawith.authdomain.jwt.JWTProvider;
+import com.pawith.authdomain.service.TokenDeleteService;
+import com.pawith.commonmodule.UnitTestConfig;
+import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.mockito.BDDMockito.given;
+@Slf4j
+@UnitTestConfig
+@DisplayName("ReissueUseCaseImpl 테스트")
+class ReissueUseCaseImplTest {
+
+    @Mock
+    private JWTProvider jwtProvider;
+    @Mock
+    private TokenDeleteService tokenDeleteService;
+
+    private ReissueUseCaseImpl reissueUseCase;
+
+    @BeforeEach
+    void setUp() {
+        reissueUseCase = new ReissueUseCaseImpl(jwtProvider, tokenDeleteService);
+    }
+
+    @Test
+    @DisplayName("reissue 테스트")
+    void reissue() {
+        // given
+        final String refreshToken = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(String.class);
+        final String reissueAccessToken = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(String.class);
+        final String reissueRefreshToken = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(String.class);
+        given(jwtProvider.reIssueAccessToken(refreshToken)).willReturn(reissueAccessToken);
+        given(jwtProvider.reIssueRefreshToken(refreshToken)).willReturn(reissueRefreshToken);
+        // when
+        TokenReissueResponse reissue = reissueUseCase.reissue(AuthConsts.AUTHENTICATION_TYPE_PREFIX + refreshToken);
+        // then
+        Assertions.assertThat(reissue.getAccessToken()).isEqualTo(AuthConsts.AUTHENTICATION_TYPE_PREFIX + reissueAccessToken);
+        Assertions.assertThat(reissue.getRefreshToken()).isEqualTo(AuthConsts.AUTHENTICATION_TYPE_PREFIX + reissueRefreshToken);
+    }
+
+}

--- a/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/repository/TokenRepository.java
+++ b/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/repository/TokenRepository.java
@@ -11,4 +11,6 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
     Optional<Token> findByValueAndTokenType(String email, TokenType tokenType);
 
     List<Token> findAllByEmailAndTokenType(String email, TokenType tokenType);
+
+    void deleteByValue(String value);
 }

--- a/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/TokenDeleteService.java
+++ b/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/TokenDeleteService.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 public interface TokenDeleteService {
 
-    void deleteRefreshToken(final Token token);
+    void deleteToken(final Token token);
 
     void deleteAllToken(final List<Token> tokenList);
+
+    void deleteTokenByValue(final String value);
 }

--- a/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/impl/TokenDeleteServiceImpl.java
+++ b/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/service/impl/TokenDeleteServiceImpl.java
@@ -16,11 +16,16 @@ public class TokenDeleteServiceImpl implements TokenDeleteService {
 
     private final TokenRepository tokenRepository;
 
-    public void deleteRefreshToken(final Token token){
+    public void deleteToken(final Token token){
         tokenRepository.delete(token);
     }
 
     public void deleteAllToken(final List<Token> tokenList){
         tokenRepository.deleteAll(tokenList);
+    }
+
+    @Override
+    public void deleteTokenByValue(String value) {
+        tokenRepository.deleteByValue(value);
     }
 }

--- a/Domain-Module/Auth-Module/Auth-Presentation/src/docs/asciidoc/Auth-API.adoc
+++ b/Domain-Module/Auth-Module/Auth-Presentation/src/docs/asciidoc/Auth-API.adoc
@@ -10,3 +10,8 @@ operation::o-auth-controller-test/o-auth-login[snippets='http-request,path-param
 === Auth 로그아웃
 
 operation::o-auth-controller-test/logout[snippets='http-request,request-headers,http-response']
+
+[[Auth-토큰-재발급]]
+=== Auth 토큰 재발급
+
+operation::o-auth-controller-test/reissue[snippets='http-request,request-headers,http-response,response-fields']

--- a/Domain-Module/Auth-Module/Auth-Presentation/src/main/java/com/pawith/authpresentation/OAuthController.java
+++ b/Domain-Module/Auth-Module/Auth-Presentation/src/main/java/com/pawith/authpresentation/OAuthController.java
@@ -1,9 +1,12 @@
 package com.pawith.authpresentation;
 
+import com.pawith.authapplication.consts.AuthConsts;
 import com.pawith.authapplication.dto.OAuthResponse;
+import com.pawith.authapplication.dto.TokenReissueResponse;
 import com.pawith.authapplication.service.LogoutUseCase;
-import com.pawith.commonmodule.enums.Provider;
 import com.pawith.authapplication.service.OAuthUseCase;
+import com.pawith.authapplication.service.ReissueUseCase;
+import com.pawith.commonmodule.enums.Provider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +18,7 @@ public class OAuthController {
 
     private final OAuthUseCase oAuthUseCase;
     private final LogoutUseCase logoutUseCase;
+    private final ReissueUseCase reissueUseCase;
 
     @GetMapping("/oauth/{provider}")
     public OAuthResponse oAuthLogin(@PathVariable Provider provider, @RequestParam String accessToken){
@@ -22,8 +26,14 @@ public class OAuthController {
         return oAuthUseCase.oAuthLogin(provider, accessToken);
     }
 
+    @PostMapping("/reissue")
+    public TokenReissueResponse reissue(@RequestHeader(AuthConsts.REFRESH_TOKEN_HEADER) String refreshToken){
+        return reissueUseCase.reissue(refreshToken);
+    }
+
+
     @DeleteMapping("/logout")
-    public void logout(@RequestHeader("RefreshToken") String refreshToken){
+    public void logout(@RequestHeader(AuthConsts.REFRESH_TOKEN_HEADER) String refreshToken){
         logoutUseCase.logoutAccessUser(refreshToken);
     }
 


### PR DESCRIPTION
## 작업사항
- 토큰 재발급 API 추가
- 토큰 재발급 API 테스트 및 명세 추가
- FixtureMonkeyUtils에서 자바 기본 타입 String에 관해서 추가 설정했습니다.
- Auth-Application 서비스 클래스들 @Service -> @ApplicationService로 수정
- AuthConsts에 "Bearer " 값을 가지는 AUTHENTICATION_TYPE_PREFIX 추가

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



