### PR TITLE
Pet 138 feat : 관리자 페이지 권한 수정 API 추가

### DIFF
--- a/.deploy/Dockerfile
+++ b/.deploy/Dockerfile
@@ -1,4 +1,4 @@
 FROM amazoncorretto:11
 ARG JAR_FILE=/Api-Module/build/libs/Api-Module-0.0.1.jar
 COPY ${JAR_FILE} pawith.jar
-ENTRYPOINT ["java","-jar","/pawith.jar"]
+ENTRYPOINT ["java","-Dcom.mysql.cj.disableAbandonedConnectionCleanup=true","-jar","/pawith.jar"]

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/ManageRegisterInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/ManageRegisterInfoResponse.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class RegisterSimpleInfoResponse {
+public class ManageRegisterInfoResponse {
     private final Long registerId;
+    private final String authority;
     private final String registerName;
+    private final String registerEmail;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/ManageRegisterListResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/ManageRegisterListResponse.java
@@ -3,9 +3,11 @@ package com.pawith.todoapplication.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @AllArgsConstructor
-public class RegisterSimpleInfoResponse {
-    private final Long registerId;
-    private final String registerName;
+public class ManageRegisterListResponse {
+
+    List<ManageRegisterInfoResponse> registers;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterSimpleInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterSimpleInfoResponse.java
@@ -7,5 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class RegisterSimpleInfoResponse {
     private final Long registerId;
+    private final String authority;
     private final String registerName;
+    private final String registerEmail;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoTeamMapper.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoTeamMapper.java
@@ -1,6 +1,7 @@
 package com.pawith.todoapplication.mapper;
 
 import com.pawith.todoapplication.dto.request.TodoTeamCreateRequest;
+import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSimpleResponse;
 import com.pawith.tododomain.entity.Register;
@@ -43,5 +44,9 @@ public class TodoTeamMapper {
             .presidentName(user.getNickname())
             .registerCount(registerCount)
             .build();
+    }
+
+    public static TodoTeamRandomCodeResponse mapToTodoTeamRandomCodeResponse(final TodoTeam todoTeam) {
+        return new TodoTeamRandomCodeResponse(todoTeam.getTeamCode());
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/ChangeRegisterUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/ChangeRegisterUseCase.java
@@ -1,0 +1,21 @@
+package com.pawith.todoapplication.service;
+
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.tododomain.entity.Register;
+import com.pawith.tododomain.service.RegisterQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional
+public class ChangeRegisterUseCase {
+
+    private final RegisterQueryService registerQueryService;
+
+    public void changeAuthority(Long registerId, String authority) {
+        Register register = registerQueryService.findRegisterById(registerId);
+        register.updateAuthority(authority);
+    }
+
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
@@ -33,7 +33,7 @@ public class RegistersGetUseCase {
         final List<RegisterSimpleInfoResponse> registerSimpleInfoResponses = allRegisters.stream()
             .map(register -> {
                 final User findUser = userQueryService.findById(register.getUserId());
-                return new RegisterSimpleInfoResponse(register.getId(), findUser.getNickname());
+                return new RegisterSimpleInfoResponse(register.getId(), register.getAuthority().toString(), findUser.getNickname(), findUser.getEmail());
             })
             .collect(Collectors.toList());
         return new RegisterListResponse(registerSimpleInfoResponses);

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
@@ -1,9 +1,7 @@
 package com.pawith.todoapplication.service;
 
 import com.pawith.commonmodule.annotation.ApplicationService;
-import com.pawith.todoapplication.dto.response.RegisterListResponse;
-import com.pawith.todoapplication.dto.response.RegisterSimpleInfoResponse;
-import com.pawith.todoapplication.dto.response.RegisterTermResponse;
+import com.pawith.todoapplication.dto.response.*;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.service.RegisterQueryService;
 import com.pawith.userdomain.entity.User;
@@ -33,10 +31,22 @@ public class RegistersGetUseCase {
         final List<RegisterSimpleInfoResponse> registerSimpleInfoResponses = allRegisters.stream()
             .map(register -> {
                 final User findUser = userQueryService.findById(register.getUserId());
-                return new RegisterSimpleInfoResponse(register.getId(), register.getAuthority().toString(), findUser.getNickname(), findUser.getEmail());
+                return new RegisterSimpleInfoResponse(register.getId(), findUser.getNickname());
             })
             .collect(Collectors.toList());
         return new RegisterListResponse(registerSimpleInfoResponses);
+    }
+
+    public ManageRegisterListResponse getManageRegisters(final Long teamId) {
+        final User user = userUtils.getAccessUser();
+        final List<Register> allRegisters = registerQueryService.findAllRegisters(user.getId(), teamId);
+        final List<ManageRegisterInfoResponse> manageRegisterInfoResponses = allRegisters.stream()
+                .map(register -> {
+                    final User findUser = userQueryService.findById(register.getUserId());
+                    return new ManageRegisterInfoResponse(register.getId(), register.getAuthority().toString(), findUser.getNickname(), findUser.getEmail());
+                })
+                .collect(Collectors.toList());
+        return new ManageRegisterListResponse(manageRegisterInfoResponses);
     }
 
     public RegisterTermResponse getRegisterTerm(final Long teamId) {

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
@@ -3,6 +3,7 @@ package com.pawith.todoapplication.service;
 import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.commonmodule.slice.SliceResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamNameSimpleResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSimpleResponse;
 import com.pawith.todoapplication.mapper.TodoTeamMapper;
@@ -54,5 +55,10 @@ public class TodoTeamGetUseCase {
         final User presidentUser = userQueryService.findById(presidentRegister.getUserId());
         final Integer registerCount = registerQueryService.countRegisterByTodoTeamId(todoTeam.getId());
         return TodoTeamMapper.mapToTodoTeamSearchInfoResponse(todoTeam, presidentUser, registerCount);
+    }
+
+    public TodoTeamRandomCodeResponse getTodoTeamCode(Long teamId) {
+        TodoTeam todoTeam = todoTeamQueryService.findTodoTeamById(teamId);
+        return TodoTeamMapper.mapToTodoTeamRandomCodeResponse(todoTeam);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/ChangeRegisterUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/ChangeRegisterUseCaseTest.java
@@ -1,0 +1,42 @@
+package com.pawith.todoapplication.service;
+
+import com.pawith.commonmodule.UnitTestConfig;
+import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import com.pawith.tododomain.entity.Authority;
+import com.pawith.tododomain.entity.Register;
+import com.pawith.tododomain.service.RegisterQueryService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.mockito.BDDMockito.given;
+
+@UnitTestConfig
+@DisplayName("ChangeRegisterUseCase 테스트")
+public class ChangeRegisterUseCaseTest {
+
+    @Mock
+    private RegisterQueryService registerQueryService;
+    private ChangeRegisterUseCase changeRegisterUseCase;
+
+    @BeforeEach
+    void init() {
+        changeRegisterUseCase = new ChangeRegisterUseCase(registerQueryService);
+    }
+
+    @Test
+    @DisplayName("Register 권한 변경 테스트")
+    void changeAuthority() {
+        // given
+        final Register mockRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(Register.class);
+        final Long registerId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        final String authority = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Authority.class).toString();
+        given(registerQueryService.findRegisterById(registerId)).willReturn(mockRegister);
+        // when
+        changeRegisterUseCase.changeAuthority(registerId, authority);
+        // then
+        Assertions.assertThat(mockRegister.getAuthority()).isEqualTo(Authority.valueOf(authority));
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoTeamGetUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoTeamGetUseCaseTest.java
@@ -1,0 +1,124 @@
+package com.pawith.todoapplication.service;
+
+import com.pawith.commonmodule.UnitTestConfig;
+import com.pawith.commonmodule.slice.SliceResponse;
+import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import com.pawith.todoapplication.dto.response.TodoTeamNameSimpleResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamSimpleResponse;
+import com.pawith.tododomain.entity.Register;
+import com.pawith.tododomain.entity.TodoTeam;
+import com.pawith.tododomain.service.RegisterQueryService;
+import com.pawith.tododomain.service.TodoTeamQueryService;
+import com.pawith.userdomain.entity.User;
+import com.pawith.userdomain.service.UserQueryService;
+import com.pawith.userdomain.utils.UserUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+
+@UnitTestConfig
+@DisplayName("TodoTeamGetUseCase 테스트")
+public class TodoTeamGetUseCaseTest {
+
+    @Mock
+    private UserUtils userUtils;
+    @Mock
+    private RegisterQueryService registerQueryService;
+    @Mock
+    private TodoTeamQueryService todoTeamQueryService;
+    @Mock
+    private UserQueryService userQueryService;
+
+    private TodoTeamGetUseCase todoTeamGetUseCase;
+
+    @BeforeEach
+    void init() {
+        todoTeamGetUseCase = new TodoTeamGetUseCase(userUtils, registerQueryService, todoTeamQueryService, userQueryService);
+    }
+
+    @Test
+    @DisplayName("사용자가 가입한 TodoTeam 조회 테스트")
+    void getTodoTeams() {
+        // given
+        final Pageable mockPageable = PageRequest.of(0,10);
+        final User mockUser = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(User.class);
+        final List<TodoTeamSimpleResponse> todoTeamSimpleResponseList = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(TodoTeamSimpleResponse.class, mockPageable.getPageSize());
+        final List<Register> registerList = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(Register.class, mockPageable.getPageSize());
+        final Slice<Register> registers = new SliceImpl<>(registerList, mockPageable, true);
+        given(userUtils.getAccessUser()).willReturn(mockUser);
+        given(registerQueryService.findRegisterSliceByUserId(mockUser.getId(), mockPageable)).willReturn(registers);
+        // when
+        SliceResponse<TodoTeamSimpleResponse> result = todoTeamGetUseCase.getTodoTeams(mockPageable);
+        // then
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result.getContent()).isNotNull();
+        Assertions.assertThat(result.getContent().size()).isEqualTo(todoTeamSimpleResponseList.size());
+    }
+
+    @Test
+    @DisplayName("사용자가 가입한 TodoTeam 이름 조회 테스트")
+    void getTodoTeamName() {
+        // given
+        final User mockUser = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(User.class);
+        final List<TodoTeam> todoTeamList = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(TodoTeam.class, 10);
+        given(userUtils.getAccessUser()).willReturn(mockUser);
+        given(todoTeamQueryService.findAllTodoTeamByUserId(mockUser.getId())).willReturn(todoTeamList);
+        // when
+        List<TodoTeamNameSimpleResponse> result = todoTeamGetUseCase.getTodoTeamName();
+        // then
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result.size()).isEqualTo(todoTeamList.size());
+    }
+
+    @Test
+    @DisplayName("TodoTeam 코드로 조회 테스트")
+    void searchTodoTeamByCode() {
+        // given
+        final String code = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(String.class);
+        final TodoTeam todoTeam = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(TodoTeam.class);
+        final Register presidentRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(Register.class);
+        final User presidentUser = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(User.class);
+        final Integer registerCount = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Integer.class);
+        given(todoTeamQueryService.findTodoTeamByCode(code)).willReturn(todoTeam);
+        given(registerQueryService.findPresidentRegisterByTodoTeamId(todoTeam.getId())).willReturn(presidentRegister);
+        given(userQueryService.findById(presidentRegister.getUserId())).willReturn(presidentUser);
+        given(registerQueryService.countRegisterByTodoTeamId(todoTeam.getId())).willReturn(registerCount);
+        // when
+        TodoTeamSearchInfoResponse result = todoTeamGetUseCase.searchTodoTeamByCode(code);
+        // then
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result.getCode()).isEqualTo(todoTeam.getTeamCode());
+        Assertions.assertThat(result.getTeamName()).isEqualTo(todoTeam.getTeamName());
+        Assertions.assertThat(result.getPresidentName()).isEqualTo(presidentUser.getNickname());
+        Assertions.assertThat(result.getRegisterCount()).isEqualTo(registerCount);
+        Assertions.assertThat(result.getDescription()).isEqualTo(null);
+        Assertions.assertThat(result.getTeamImageUrl()).isEqualTo(todoTeam.getImageUrl());
+
+    }
+
+    @Test
+    @DisplayName("TodoTeamId로 TodoTeam 코드 조회 테스트")
+    void getTodoTeamCode() {
+        // given
+        final Long teamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        final TodoTeam todoTeam = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(TodoTeam.class);
+        given(todoTeamQueryService.findTodoTeamById(teamId)).willReturn(todoTeam);
+        // when
+        TodoTeamRandomCodeResponse result = todoTeamGetUseCase.getTodoTeamCode(teamId);
+        // then
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result.getRandomCode()).isEqualTo(todoTeam.getTeamCode());
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Register.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Register.java
@@ -4,6 +4,7 @@ import com.pawith.commonmodule.domain.BaseEntity;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.Arrays;
 
 @Entity
 @Getter
@@ -29,5 +30,16 @@ public class Register extends BaseEntity {
         this.authority = authority;
         this.todoTeam = todoTeam;
         this.userId = userId;
+    }
+
+    public void updateAuthority(String authority) {
+        if(!this.authority.toString().equals(authority) && authority != null && isValidAuthority(authority)) {
+            this.authority = Authority.valueOf(authority);
+        }
+    }
+
+    private boolean isValidAuthority(String authority) {
+        return Arrays.stream(Authority.values())
+                .anyMatch(enumValue -> enumValue.name().equals(authority));
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -33,6 +33,11 @@ operation::todo-team-controller-test/post-todo-team[snippets='http-request,reque
 operation::todo-team-controller-test/get-todo-team-random-code[snippets='http-request,request-headers,http-response,response-fields']
 
 [[Todo-API-Todo-Team-Code-조회]]
+=== Todo Team Id로 Todo Team Code 조회
+
+operation::todo-team-controller-test/get-todo-team-code[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
+[[Todo-API-Todo-Team-Code-조회]]
 === Todo Team Code로 Todo Team 조회
 
 operation::todo-team-controller-test/get-todo-team-by-code[snippets='http-request,request-parameters,request-headers,http-response,response-fields']

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -11,6 +11,11 @@ operation::todo-team-controller-test/get-todo-teams[snippets='http-request,reque
 
 operation::register-controller-test/get-registers[snippets='http-request,request-parameters,request-headers,http-response,response-fields']
 
+[[Todo-API-Todo-Team에-가입된-사용자-권한-수정]]
+=== Todo Team에 가입된 사용자 권한 수정
+
+operation::register-controller-test/change-authority[snippets='http-request,path-parameters,request-parameters,request-headers,http-response']
+
 
 [[Todo-API-Todo-Team-탈퇴]]
 === Todo Team 탈퇴

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -7,9 +7,14 @@
 operation::todo-team-controller-test/get-todo-teams[snippets='http-request,request-parameters,request-headers,http-response,response-fields']
 
 [[Todo-API-Todo-Team에-가입된-사용자-조회]]
-=== Todo Team에 가입된 사용자 조회
+=== Todo Team에 가입된 사용자 조회 (todo 생성할 때 사용)
 
 operation::register-controller-test/get-registers[snippets='http-request,request-parameters,request-headers,http-response,response-fields']
+
+[[Todo-API-Todo-Team에-가입된-사용자-조회]]
+=== Todo Team에 가입된 사용자 조회 (관리자 페이지에서 회원 정보 조회할 때 사용)
+
+operation::register-controller-test/get-manage-registers[snippets='http-request,request-parameters,request-headers,http-response,response-fields']
 
 [[Todo-API-Todo-Team에-가입된-사용자-권한-수정]]
 === Todo Team에 가입된 사용자 권한 수정

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
@@ -1,5 +1,6 @@
 package com.pawith.todopresentation;
 
+import com.pawith.todoapplication.dto.response.ManageRegisterListResponse;
 import com.pawith.todoapplication.dto.response.RegisterListResponse;
 import com.pawith.todoapplication.service.ChangeRegisterUseCase;
 import com.pawith.todoapplication.service.RegistersGetUseCase;
@@ -31,6 +32,11 @@ public class RegisterController {
     @GetMapping("/list")
     public RegisterListResponse getRegisters(@RequestParam Long teamId){
         return registersGetUseCase.getRegisters(teamId);
+    }
+
+    @GetMapping("/manage/list")
+    public ManageRegisterListResponse getManageRegisters(@RequestParam Long teamId){
+        return registersGetUseCase.getManageRegisters(teamId);
     }
 
     @PostMapping("/{registerId}")

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
@@ -1,6 +1,7 @@
 package com.pawith.todopresentation;
 
 import com.pawith.todoapplication.dto.response.RegisterListResponse;
+import com.pawith.todoapplication.service.ChangeRegisterUseCase;
 import com.pawith.todoapplication.service.RegistersGetUseCase;
 import com.pawith.todoapplication.service.TodoTeamRegisterUseCase;
 import com.pawith.todoapplication.service.UnregisterUseCase;
@@ -15,6 +16,7 @@ public class RegisterController {
     private final UnregisterUseCase unregisterUseCase;
     private final TodoTeamRegisterUseCase todoTeamRegisterUseCase;
     private final RegistersGetUseCase registersGetUseCase;
+    private final ChangeRegisterUseCase changeRegisterUseCase;
 
     @DeleteMapping("/{todoTeamId}")
     public void deleteRegister(@PathVariable Long todoTeamId) {
@@ -29,5 +31,10 @@ public class RegisterController {
     @GetMapping("/list")
     public RegisterListResponse getRegisters(@RequestParam Long teamId){
         return registersGetUseCase.getRegisters(teamId);
+    }
+
+    @PostMapping("/{registerId}")
+    public void changeAuthority(@PathVariable Long registerId, @RequestParam String authority) {
+        changeRegisterUseCase.changeAuthority(registerId, authority);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
@@ -67,4 +67,9 @@ public class TodoTeamController {
     public List<TodoTeamNameSimpleResponse> getTodoTeamName() {
         return todoTeamGetUseCase.getTodoTeamName();
     }
+
+    @GetMapping("/code/{teamId}")
+    public TodoTeamRandomCodeResponse getTodoTeamCode(@PathVariable Long teamId){
+        return todoTeamGetUseCase.getTodoTeamCode(teamId);
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -125,7 +125,7 @@ class RegisterControllerTest extends BaseRestDocsTest {
         //given
         final Long registerId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
         final String authority = Authrotity;
-        MockHttpServletRequestBuilder request = post(REGISTER_REQUEST_URL + "/authority/{registerId}", registerId)
+        MockHttpServletRequestBuilder request = post(REGISTER_REQUEST_URL + "/{registerId}", registerId)
             .queryParam("authority", authority)
             .header("Authorization", "Bearer accessToken");
         //when

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -5,6 +5,7 @@ import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
 import com.pawith.todoapplication.dto.response.RegisterListResponse;
 import com.pawith.todoapplication.dto.response.RegisterSimpleInfoResponse;
+import com.pawith.todoapplication.service.ChangeRegisterUseCase;
 import com.pawith.todoapplication.service.RegistersGetUseCase;
 import com.pawith.todoapplication.service.TodoTeamRegisterUseCase;
 import com.pawith.todoapplication.service.UnregisterUseCase;
@@ -38,8 +39,11 @@ class RegisterControllerTest extends BaseRestDocsTest {
     private TodoTeamRegisterUseCase todoTeamRegisterUseCase;
     @MockBean
     private RegistersGetUseCase registersGetUseCase;
+    @MockBean
+    private ChangeRegisterUseCase changeRegisterUseCase;
 
     private static final String REGISTER_REQUEST_URL = "/register";
+    private static final String Authrotity = "EXECUTIVE";
 
     @Test
     @DisplayName("TodoTeamId로 TodoTeam을 삭제하는 테스트")
@@ -107,9 +111,37 @@ class RegisterControllerTest extends BaseRestDocsTest {
                 ),
                 responseFields(
                     fieldWithPath("registers[].registerId").description("TodoTeam에 등록된 사용자 registerId"),
-                    fieldWithPath("registers[].registerName").description("TodoTeam에 등록된 사용자 이름")
+                    fieldWithPath("registers[].authority").description("TodoTeam에 등록된 사용자 권한"),
+                    fieldWithPath("registers[].registerName").description("TodoTeam에 등록된 사용자 이름"),
+                    fieldWithPath("registers[].registerEmail").description("TodoTeam에 등록된 사용자 이메일")
                 )
             ));
 
+    }
+
+    @Test
+    @DisplayName("Register의 권한을 변경하는 테스트")
+    void changeAuthority() throws Exception {
+        //given
+        final Long registerId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        final String authority = Authrotity;
+        MockHttpServletRequestBuilder request = post(REGISTER_REQUEST_URL + "/authority/{registerId}", registerId)
+            .queryParam("authority", authority)
+            .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+            .andDo(resultHandler.document(
+                requestHeaders(
+                    headerWithName("Authorization").description("access 토큰")
+                ),
+                pathParameters(
+                    parameterWithName("registerId").description("변경할 register의 Id")
+                ),
+                requestParameters(
+                    parameterWithName("authority").description("변경할 register의 권한")
+                )
+            ));
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -3,6 +3,8 @@ package com.pawith.todopresentation;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import com.pawith.todoapplication.dto.response.ManageRegisterInfoResponse;
+import com.pawith.todoapplication.dto.response.ManageRegisterListResponse;
 import com.pawith.todoapplication.dto.response.RegisterListResponse;
 import com.pawith.todoapplication.dto.response.RegisterSimpleInfoResponse;
 import com.pawith.todoapplication.service.ChangeRegisterUseCase;
@@ -111,11 +113,41 @@ class RegisterControllerTest extends BaseRestDocsTest {
                 ),
                 responseFields(
                     fieldWithPath("registers[].registerId").description("TodoTeam에 등록된 사용자 registerId"),
-                    fieldWithPath("registers[].authority").description("TodoTeam에 등록된 사용자 권한"),
-                    fieldWithPath("registers[].registerName").description("TodoTeam에 등록된 사용자 이름"),
-                    fieldWithPath("registers[].registerEmail").description("TodoTeam에 등록된 사용자 이메일")
+                    fieldWithPath("registers[].registerName").description("TodoTeam에 등록된 사용자 이메일")
                 )
             ));
+
+    }
+
+
+    @Test
+    @DisplayName("TodoTeam의 등록된 Register들을 조회하는 테스트 (관리자 페이지에서 사용)")
+    void getManageRegisters() throws Exception {
+        //given
+        final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
+        final List<ManageRegisterInfoResponse> manageRegisterInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(ManageRegisterInfoResponse.class, 10);
+        final ManageRegisterListResponse manageRegisterListResponse = new ManageRegisterListResponse(manageRegisterInfoResponses);
+        given(registersGetUseCase.getManageRegisters(todoTeamId)).willReturn(manageRegisterListResponse);
+        MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/manage/list?teamId={teamId}", todoTeamId)
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        requestParameters(
+                                parameterWithName("teamId").description("조회하는 TodoTeamId")
+                        ),
+                        responseFields(
+                                fieldWithPath("registers[].registerId").description("TodoTeam에 등록된 사용자 registerId"),
+                                fieldWithPath("registers[].authority").description("TodoTeam에 등록된 사용자 권한"),
+                                fieldWithPath("registers[].registerName").description("TodoTeam에 등록된 사용자 이름"),
+                                fieldWithPath("registers[].registerEmail").description("TodoTeam에 등록된 사용자 이메일")
+                        )
+                ));
 
     }
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -32,8 +32,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Slf4j
@@ -127,6 +126,31 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
                     fieldWithPath("randomCode").description("랜덤 코드")
                 )
             ));
+    }
+
+    @Test
+    @DisplayName("teamId를 이용해서 TodoTeam의 code를 조회 테스트")
+    void getTodoTeamCode() throws Exception {
+        //given
+        final Long teamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        given(todoTeamGetUseCase.getTodoTeamCode(teamId)).willReturn(new TodoTeamRandomCodeResponse("randomCode"));
+        MockHttpServletRequestBuilder request = get(TODO_TEAM_REQUEST_URL + "/code/{teamId}", teamId)
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("TodoTeam의 Id")
+                        ),
+                        responseFields(
+                                fieldWithPath("randomCode").description("TodoTeam의 코드")
+                        )
+                ));
     }
 
     @Test


### PR DESCRIPTION
## 작업사항
- 팀 코드 조회 API 추가, 명세 추가
- 관리자 페이지 회원 권환 수정 API 추가, 명세 추가
- 관련 application service 테스트 추가

## 변경로직
- 가입한 팀원들 조회 API ResponseDto (RegisterSimpleInfoResponse) 추가 정보 필드 추가

## 참고자료
- 내용을 적어주세요.



