### PR TITLE
Pet 150 refactor : Register API URL 형식 변경

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/register")
+@RequestMapping("/registers")
 public class RegisterController {
 
     private final UnregisterUseCase unregisterUseCase;
@@ -30,14 +30,14 @@ public class RegisterController {
         todoTeamRegisterUseCase.registerTodoTeam(todoTeamCode);
     }
 
-    @GetMapping("/list")
-    public RegisterListResponse getRegisters(@RequestParam Long teamId){
-        return registersGetUseCase.getRegisters(teamId);
+    @GetMapping("/{todoTeamId}")
+    public RegisterListResponse getRegisters(@PathVariable Long todoTeamId){
+        return registersGetUseCase.getRegisters(todoTeamId);
     }
 
-    @GetMapping("/manage/list")
-    public ManageRegisterListResponse getManageRegisters(@RequestParam Long teamId){
-        return registersGetUseCase.getManageRegisters(teamId);
+    @GetMapping("/{todoTeamId}/manage")
+    public ManageRegisterListResponse getRegistersForManage(@PathVariable Long todoTeamId){
+        return registersGetUseCase.getManageRegisters(todoTeamId);
     }
 
     @PutMapping("/{registerId}")

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -44,7 +44,7 @@ class RegisterControllerTest extends BaseRestDocsTest {
     @MockBean
     private ChangeRegisterUseCase changeRegisterUseCase;
 
-    private static final String REGISTER_REQUEST_URL = "/register";
+    private static final String REGISTER_REQUEST_URL = "/registers";
     private static final String Authrotity = "EXECUTIVE";
 
     @Test
@@ -98,7 +98,7 @@ class RegisterControllerTest extends BaseRestDocsTest {
         final List<RegisterSimpleInfoResponse> registerSimpleInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(RegisterSimpleInfoResponse.class, 10);
         final RegisterListResponse registerListResponse = new RegisterListResponse(registerSimpleInfoResponses);
         given(registersGetUseCase.getRegisters(todoTeamId)).willReturn(registerListResponse);
-        MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/list?teamId={teamId}", todoTeamId)
+        MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}",todoTeamId)
             .header("Authorization", "Bearer accessToken");
         //when
         ResultActions result = mvc.perform(request);
@@ -108,8 +108,8 @@ class RegisterControllerTest extends BaseRestDocsTest {
                 requestHeaders(
                     headerWithName("Authorization").description("access 토큰")
                 ),
-                requestParameters(
-                    parameterWithName("teamId").description("조회하는 TodoTeamId")
+                pathParameters(
+                    parameterWithName("todoTeamId").description("조회하는 TodoTeamId")
                 ),
                 responseFields(
                     fieldWithPath("registers[].registerId").description("TodoTeam에 등록된 사용자 registerId"),
@@ -128,7 +128,7 @@ class RegisterControllerTest extends BaseRestDocsTest {
         final List<ManageRegisterInfoResponse> manageRegisterInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(ManageRegisterInfoResponse.class, 10);
         final ManageRegisterListResponse manageRegisterListResponse = new ManageRegisterListResponse(manageRegisterInfoResponses);
         given(registersGetUseCase.getManageRegisters(todoTeamId)).willReturn(manageRegisterListResponse);
-        MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/manage/list?teamId={teamId}", todoTeamId)
+        MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}"+"/manage",todoTeamId)
                 .header("Authorization", "Bearer accessToken");
         //when
         ResultActions result = mvc.perform(request);
@@ -138,8 +138,8 @@ class RegisterControllerTest extends BaseRestDocsTest {
                         requestHeaders(
                                 headerWithName("Authorization").description("access 토큰")
                         ),
-                        requestParameters(
-                                parameterWithName("teamId").description("조회하는 TodoTeamId")
+                        pathParameters(
+                                parameterWithName("todoTeamId").description("조회하는 TodoTeamId")
                         ),
                         responseFields(
                                 fieldWithPath("registers[].registerId").description("TodoTeam에 등록된 사용자 registerId"),


### PR DESCRIPTION
## 작업사항
- url 컨밴션에 맞게 수정

## 변경로직
- 내용을 적어주세요.

## 참고자료
1. url 시작은 복수형으로하고
2. 세부 조회 (ex: registers/manage/list?teamId=123)의 url형식을 (registers/123/manage)로 설정하기
3. 메소드 이름은 httpMethod+조회내용+세부사항(getRegistersForManage)



