### PR TITLE
Pet 155 refactor : DTO 네이밍 수정

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategoryInfoListResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategoryInfoListResponse.java
@@ -3,9 +3,10 @@ package com.pawith.todoapplication.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @AllArgsConstructor
-public class RegisterSimpleInfoResponse {
-    private final Long registerId;
-    private final String registerName;
+public class CategoryInfoListResponse {
+    private final List<CategoryInfoResponse> categories;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoListResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoListResponse.java
@@ -5,13 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.List;
+
 @Getter
 @ToString
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
-public class TodoHomeResponse {
-
-    private Long todoId;
-    private String task;
-    private String status;
-
+public class CategorySubTodoListResponse {
+    private List<CategorySubTodoResponse> todos;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 @ToString
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class CategorySubTodoResponse {
-
     private Long todoId;
     private String task;
     private String status;

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterInfoListResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterInfoListResponse.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class ManageRegisterListResponse {
-
-    List<ManageRegisterInfoResponse> registers;
+public class RegisterInfoListResponse {
+    private final List<RegisterInfoResponse> registers;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterInfoResponse.java
@@ -3,10 +3,9 @@ package com.pawith.todoapplication.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
 @AllArgsConstructor
-public class RegisterListResponse {
-    private final List<RegisterSimpleInfoResponse> registers;
+public class RegisterInfoResponse {
+    private final Long registerId;
+    private final String registerName;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterManageInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterManageInfoResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ManageRegisterInfoResponse {
+public class RegisterManageInfoResponse {
     private final Long registerId;
     private final String authority;
     private final String registerName;

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterManageListResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterManageListResponse.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class CategoryListResponse {
-    private final List<CategoryInfoResponse> categories;
+public class RegisterManageListResponse {
+    List<RegisterManageInfoResponse> registers;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoInfoResponse.java
@@ -5,12 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.List;
-
 @Getter
 @ToString
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
-public class TodoListResponse {
-    private List<CategorySubTodoResponse> todos;
-
+public class TodoInfoResponse {
+    private Long todoId;
+    private String task;
+    private String status;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoProgressRateCompareResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoProgressRateCompareResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class TodoRateCompareResponse {
+public class TodoProgressRateCompareResponse {
     private ComparisonResult compareWithLastWeek;
 
     public enum ComparisonResult {
@@ -14,7 +14,7 @@ public class TodoRateCompareResponse {
         LOWER
     }
 
-    public TodoRateCompareResponse(Boolean isHigher, Boolean isSame) {
+    public TodoProgressRateCompareResponse(Boolean isHigher, Boolean isSame) {
         if (isHigher) {
             compareWithLastWeek = ComparisonResult.HIGHER;
         } else if (isSame) {

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamInfoResponse.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
-public class TodoTeamSimpleResponse {
+public class TodoTeamInfoResponse {
     private Long teamId;
     private String teamProfileImageUrl;
     private String teamName;

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamNameResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamNameResponse.java
@@ -5,7 +5,7 @@ import lombok.*;
 @Getter
 @ToString
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
-public class TodoTeamNameSimpleResponse {
+public class TodoTeamNameResponse {
     private Long teamId;
     private String teamName;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoTeamMapper.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoTeamMapper.java
@@ -3,7 +3,7 @@ package com.pawith.todoapplication.mapper;
 import com.pawith.todoapplication.dto.request.TodoTeamCreateRequest;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
-import com.pawith.todoapplication.dto.response.TodoTeamSimpleResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.entity.TodoTeam;
 import com.pawith.userdomain.entity.User;
@@ -24,9 +24,9 @@ public class TodoTeamMapper {
             .build();
     }
 
-    public static TodoTeamSimpleResponse mapToTodoTeamSimpleResponse(final TodoTeam todoTeam, final Register register) {
+    public static TodoTeamInfoResponse mapToTodoTeamSimpleResponse(final TodoTeam todoTeam, final Register register) {
         final int registerPeriod = Period.between(register.getCreatedAt().toLocalDate(), LocalDate.now()).getDays();
-        return TodoTeamSimpleResponse.builder()
+        return TodoTeamInfoResponse.builder()
             .teamId(todoTeam.getId())
             .teamName(todoTeam.getTeamName())
             .teamProfileImageUrl(todoTeam.getImageUrl())

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/CategoryGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/CategoryGetUseCase.java
@@ -2,7 +2,7 @@ package com.pawith.todoapplication.service;
 
 import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.todoapplication.dto.response.CategoryInfoResponse;
-import com.pawith.todoapplication.dto.response.CategoryListResponse;
+import com.pawith.todoapplication.dto.response.CategoryInfoListResponse;
 import com.pawith.tododomain.entity.Category;
 import com.pawith.tododomain.service.CategoryQueryService;
 import lombok.RequiredArgsConstructor;
@@ -18,11 +18,11 @@ public class CategoryGetUseCase {
 
     private final CategoryQueryService categoryQueryService;
 
-    public CategoryListResponse getCategoryList(final Long todoTeamId) {
+    public CategoryInfoListResponse getCategoryList(final Long todoTeamId) {
         List<Category> categoryList = categoryQueryService.findCategoryListByTodoTeamIdAndStatus(todoTeamId);
         List<CategoryInfoResponse> categorySimpleResponses = categoryList.stream()
             .map(category -> new CategoryInfoResponse(category.getId(), category.getName()))
             .collect(Collectors.toList());
-        return new CategoryListResponse(categorySimpleResponses);
+        return new CategoryInfoListResponse(categorySimpleResponses);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
@@ -25,28 +25,28 @@ public class RegistersGetUseCase {
     /**
      * TODO : 성능 최적화 방안으로 캐시 고민
      */
-    public RegisterListResponse getRegisters(final Long teamId) {
+    public RegisterInfoListResponse getRegisters(final Long teamId) {
         final User user = userUtils.getAccessUser();
         final List<Register> allRegisters = registerQueryService.findAllRegisters(user.getId(), teamId);
-        final List<RegisterSimpleInfoResponse> registerSimpleInfoResponses = allRegisters.stream()
+        final List<RegisterInfoResponse> registerInfoRespons = allRegisters.stream()
             .map(register -> {
                 final User findUser = userQueryService.findById(register.getUserId());
-                return new RegisterSimpleInfoResponse(register.getId(), findUser.getNickname());
+                return new RegisterInfoResponse(register.getId(), findUser.getNickname());
             })
             .collect(Collectors.toList());
-        return new RegisterListResponse(registerSimpleInfoResponses);
+        return new RegisterInfoListResponse(registerInfoRespons);
     }
 
-    public ManageRegisterListResponse getManageRegisters(final Long teamId) {
+    public RegisterManageListResponse getManageRegisters(final Long teamId) {
         final User user = userUtils.getAccessUser();
         final List<Register> allRegisters = registerQueryService.findAllRegisters(user.getId(), teamId);
-        final List<ManageRegisterInfoResponse> manageRegisterInfoResponses = allRegisters.stream()
+        final List<RegisterManageInfoResponse> registerManageInfoRespons = allRegisters.stream()
                 .map(register -> {
                     final User findUser = userQueryService.findById(register.getUserId());
-                    return new ManageRegisterInfoResponse(register.getId(), register.getAuthority().toString(), findUser.getNickname(), findUser.getEmail());
+                    return new RegisterManageInfoResponse(register.getId(), register.getAuthority().toString(), findUser.getNickname(), findUser.getEmail());
                 })
                 .collect(Collectors.toList());
-        return new ManageRegisterListResponse(manageRegisterInfoResponses);
+        return new RegisterManageListResponse(registerManageInfoRespons);
     }
 
     public RegisterTermResponse getRegisterTerm(final Long teamId) {

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -3,9 +3,9 @@ package com.pawith.todoapplication.service;
 import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.commonmodule.slice.SliceResponse;
 import com.pawith.todoapplication.dto.response.AssignUserInfoResponse;
-import com.pawith.todoapplication.dto.response.TodoHomeResponse;
+import com.pawith.todoapplication.dto.response.TodoInfoResponse;
 import com.pawith.todoapplication.dto.response.CategorySubTodoResponse;
-import com.pawith.todoapplication.dto.response.TodoListResponse;
+import com.pawith.todoapplication.dto.response.CategorySubTodoListResponse;
 import com.pawith.tododomain.entity.Assign;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.entity.Todo;
@@ -38,15 +38,15 @@ public class TodoGetUseCase {
     private final RegisterQueryService registerQueryService;
     private final AssignQueryService assignQueryService;
 
-    public SliceResponse<TodoHomeResponse> getTodoListByTodoTeamId(final Long todoTeamId, final Pageable pageable) {
+    public SliceResponse<TodoInfoResponse> getTodoListByTodoTeamId(final Long todoTeamId, final Pageable pageable) {
         final User user = userUtils.getAccessUser();
         final Slice<Todo> todoList = todoQueryService.findTodayTodoSlice(user.getId(), todoTeamId, pageable);
-        Slice<TodoHomeResponse> todoHomeResponseSlice = todoList.map(todo -> new TodoHomeResponse(todo.getId(), todo.getDescription(), todo.getTodoStatus().name()));
+        Slice<TodoInfoResponse> todoHomeResponseSlice = todoList.map(todo -> new TodoInfoResponse(todo.getId(), todo.getDescription(), todo.getTodoStatus().name()));
         return SliceResponse.from(todoHomeResponseSlice);
     }
 
 
-    public TodoListResponse getTodoListByCategoryId(Long categoryId, LocalDate moveDate) {
+    public CategorySubTodoListResponse getTodoListByCategoryId(Long categoryId, LocalDate moveDate) {
         final Map<Long, User> userMap = userQueryService.findUserMapByIds(registerQueryService::findUserIdsByCategoryId, categoryId);
         final Map<Todo, List<Register>> groupByTodo = getTodoMap(categoryId, moveDate);
         final ArrayList<CategorySubTodoResponse> todoMainResponses = new ArrayList<>();
@@ -59,7 +59,7 @@ public class TodoGetUseCase {
             }
             todoMainResponses.add(new CategorySubTodoResponse(todo.getId(), todo.getDescription(), todo.getTodoStatus().name(), assignUserInfoResponses));
         }
-        return new TodoListResponse(todoMainResponses);
+        return new CategorySubTodoListResponse(todoMainResponses);
     }
 
     private Map<Todo, List<Register>> getTodoMap(Long categoryId, LocalDate moveDate) {

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoRateGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoRateGetUseCase.java
@@ -2,7 +2,7 @@ package com.pawith.todoapplication.service;
 
 import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.todoapplication.dto.response.TodoProgressResponse;
-import com.pawith.todoapplication.dto.response.TodoRateCompareResponse;
+import com.pawith.todoapplication.dto.response.TodoProgressRateCompareResponse;
 import com.pawith.tododomain.service.TodoQueryService;
 import com.pawith.userdomain.entity.User;
 import com.pawith.userdomain.utils.UserUtils;
@@ -27,10 +27,10 @@ public class TodoRateGetUseCase {
         return new TodoProgressResponse(todoCompleteRate);
     }
 
-    public TodoRateCompareResponse getWeekProgressCompare(final Long todoTeamId) {
+    public TodoProgressRateCompareResponse getWeekProgressCompare(final Long todoTeamId) {
         final User user = userUtils.getAccessUser();
         final Integer thisWeekTodoCompleteRate = todoQueryService.findThisWeekTodoCompleteRate(user.getId(), todoTeamId);
         final Integer lastWeekTodoCompleteRate = todoQueryService.findLastWeekTodoCompleteRate(user.getId(), todoTeamId);
-        return new TodoRateCompareResponse(thisWeekTodoCompleteRate > lastWeekTodoCompleteRate, thisWeekTodoCompleteRate.equals(lastWeekTodoCompleteRate));
+        return new TodoProgressRateCompareResponse(thisWeekTodoCompleteRate > lastWeekTodoCompleteRate, thisWeekTodoCompleteRate.equals(lastWeekTodoCompleteRate));
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
@@ -2,10 +2,10 @@ package com.pawith.todoapplication.service;
 
 import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.commonmodule.slice.SliceResponse;
-import com.pawith.todoapplication.dto.response.TodoTeamNameSimpleResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
-import com.pawith.todoapplication.dto.response.TodoTeamSimpleResponse;
 import com.pawith.todoapplication.mapper.TodoTeamMapper;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.entity.TodoTeam;
@@ -33,19 +33,19 @@ public class TodoTeamGetUseCase {
     private final UserQueryService userQueryService;
 
 
-    public SliceResponse<TodoTeamSimpleResponse> getTodoTeams(final Pageable pageable) {
+    public SliceResponse<TodoTeamInfoResponse> getTodoTeams(final Pageable pageable) {
         final User requestUser = userUtils.getAccessUser();
-        final Slice<TodoTeamSimpleResponse> todoTeamSimpleResponses =
+        final Slice<TodoTeamInfoResponse> todoTeamSimpleResponses =
             registerQueryService.findRegisterSliceByUserId(requestUser.getId(), pageable)
                 .map(register -> TodoTeamMapper.mapToTodoTeamSimpleResponse(register.getTodoTeam(), register));
         return SliceResponse.from(todoTeamSimpleResponses);
     }
 
-    public List<TodoTeamNameSimpleResponse> getTodoTeamName() {
+    public List<TodoTeamNameResponse> getTodoTeamName() {
         final User requestUser = userUtils.getAccessUser();
         return todoTeamQueryService.findAllTodoTeamByUserId(requestUser.getId())
             .stream()
-            .map(todoTeam -> new TodoTeamNameSimpleResponse(todoTeam.getId(), todoTeam.getTeamName()))
+            .map(todoTeam -> new TodoTeamNameResponse(todoTeam.getId(), todoTeam.getTeamName()))
             .collect(Collectors.toList());
     }
 

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/CategoryGetUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/CategoryGetUseCaseTest.java
@@ -3,7 +3,7 @@ package com.pawith.todoapplication.service;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
-import com.pawith.todoapplication.dto.response.CategoryListResponse;
+import com.pawith.todoapplication.dto.response.CategoryInfoListResponse;
 import com.pawith.tododomain.entity.Category;
 import com.pawith.tododomain.service.CategoryQueryService;
 import org.assertj.core.api.Assertions;
@@ -38,7 +38,7 @@ public class CategoryGetUseCaseTest {
             .giveMe(Category.class, 5);
         given(categoryQueryService.findCategoryListByTodoTeamIdAndStatus(TodoTeamId)).willReturn(categoryList);
         // when
-        final CategoryListResponse result = categoryGetUseCase.getCategoryList(TodoTeamId);
+        final CategoryInfoListResponse result = categoryGetUseCase.getCategoryList(TodoTeamId);
         // then
         Assertions.assertThat(result.getCategories().size()).isEqualTo(categoryList.size());
     }

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/RegistersGetUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/RegistersGetUseCaseTest.java
@@ -3,7 +3,7 @@ package com.pawith.todoapplication.service;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
-import com.pawith.todoapplication.dto.response.RegisterListResponse;
+import com.pawith.todoapplication.dto.response.RegisterInfoListResponse;
 import com.pawith.todoapplication.dto.response.RegisterTermResponse;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.service.RegisterQueryService;
@@ -54,10 +54,10 @@ public class RegistersGetUseCaseTest {
         given(registerQueryService.findAllRegisters(mockUser.getId(), todoTeamId)).willReturn(registerList);
         given(userQueryService.findById(any())).willReturn(mockFindUser);
         // when
-        RegisterListResponse registerListResponse = registersGetUseCase.getRegisters(todoTeamId);
+        RegisterInfoListResponse registerInfoListResponse = registersGetUseCase.getRegisters(todoTeamId);
         // then
-        Assertions.assertThat(registerListResponse).isNotNull();
-        Assertions.assertThat(registerListResponse.getRegisters().size()).isEqualTo(registerList.size());
+        Assertions.assertThat(registerInfoListResponse).isNotNull();
+        Assertions.assertThat(registerInfoListResponse.getRegisters().size()).isEqualTo(registerList.size());
 
     }
 

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoGetUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoGetUseCaseTest.java
@@ -4,7 +4,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.commonmodule.slice.SliceResponse;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
-import com.pawith.todoapplication.dto.response.TodoHomeResponse;
+import com.pawith.todoapplication.dto.response.TodoInfoResponse;
 import com.pawith.tododomain.entity.Todo;
 import com.pawith.tododomain.service.AssignQueryService;
 import com.pawith.tododomain.service.CategoryQueryService;
@@ -65,7 +65,7 @@ class TodoGetUseCaseTest {
         given(userUtils.getAccessUser()).willReturn(mockUser);
         given(todoQueryService.findTodayTodoSlice(mockUser.getId(), todoTeamId, mockPageable)).willReturn(todos);
         // when
-        SliceResponse<TodoHomeResponse> result = todoGetUseCase.getTodoListByTodoTeamId(todoTeamId, mockPageable);
+        SliceResponse<TodoInfoResponse> result = todoGetUseCase.getTodoListByTodoTeamId(todoTeamId, mockPageable);
         // then
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result.getContent().size()).isEqualTo(todoList.size());

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoRateGetUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoRateGetUseCaseTest.java
@@ -4,7 +4,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
 import com.pawith.todoapplication.dto.response.TodoProgressResponse;
-import com.pawith.todoapplication.dto.response.TodoRateCompareResponse;
+import com.pawith.todoapplication.dto.response.TodoProgressRateCompareResponse;
 import com.pawith.tododomain.service.TodoQueryService;
 import com.pawith.userdomain.entity.User;
 import com.pawith.userdomain.utils.UserUtils;
@@ -62,10 +62,10 @@ class TodoRateGetUseCaseTest {
         given(todoQueryService.findThisWeekTodoCompleteRate(mockUser.getId(), todoTeamId)).willReturn(thisWeekTodoCompleteRate);
         given(todoQueryService.findLastWeekTodoCompleteRate(mockUser.getId(), todoTeamId)).willReturn(lastWeekTodoCompleteRate);
         // when
-        TodoRateCompareResponse todoRateCompareResponse = todoRateGetUseCase.getWeekProgressCompare(todoTeamId);
+        TodoProgressRateCompareResponse todoProgressRateCompareResponse = todoRateGetUseCase.getWeekProgressCompare(todoTeamId);
         // then
-        Assertions.assertThat(todoRateCompareResponse).isNotNull();
-        Assertions.assertThat(todoRateCompareResponse.getCompareWithLastWeek()).isEqualTo(TodoRateCompareResponse.ComparisonResult.HIGHER);
+        Assertions.assertThat(todoProgressRateCompareResponse).isNotNull();
+        Assertions.assertThat(todoProgressRateCompareResponse.getCompareWithLastWeek()).isEqualTo(TodoProgressRateCompareResponse.ComparisonResult.HIGHER);
     }
 
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoTeamGetUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoTeamGetUseCaseTest.java
@@ -3,10 +3,10 @@ package com.pawith.todoapplication.service;
 import com.pawith.commonmodule.UnitTestConfig;
 import com.pawith.commonmodule.slice.SliceResponse;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
-import com.pawith.todoapplication.dto.response.TodoTeamNameSimpleResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
-import com.pawith.todoapplication.dto.response.TodoTeamSimpleResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.entity.TodoTeam;
 import com.pawith.tododomain.service.RegisterQueryService;
@@ -54,17 +54,17 @@ public class TodoTeamGetUseCaseTest {
         // given
         final Pageable mockPageable = PageRequest.of(0,10);
         final User mockUser = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(User.class);
-        final List<TodoTeamSimpleResponse> todoTeamSimpleResponseList = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(TodoTeamSimpleResponse.class, mockPageable.getPageSize());
+        final List<TodoTeamInfoResponse> todoTeamInfoResponseList = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(TodoTeamInfoResponse.class, mockPageable.getPageSize());
         final List<Register> registerList = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(Register.class, mockPageable.getPageSize());
         final Slice<Register> registers = new SliceImpl<>(registerList, mockPageable, true);
         given(userUtils.getAccessUser()).willReturn(mockUser);
         given(registerQueryService.findRegisterSliceByUserId(mockUser.getId(), mockPageable)).willReturn(registers);
         // when
-        SliceResponse<TodoTeamSimpleResponse> result = todoTeamGetUseCase.getTodoTeams(mockPageable);
+        SliceResponse<TodoTeamInfoResponse> result = todoTeamGetUseCase.getTodoTeams(mockPageable);
         // then
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result.getContent()).isNotNull();
-        Assertions.assertThat(result.getContent().size()).isEqualTo(todoTeamSimpleResponseList.size());
+        Assertions.assertThat(result.getContent().size()).isEqualTo(todoTeamInfoResponseList.size());
     }
 
     @Test
@@ -76,7 +76,7 @@ public class TodoTeamGetUseCaseTest {
         given(userUtils.getAccessUser()).willReturn(mockUser);
         given(todoTeamQueryService.findAllTodoTeamByUserId(mockUser.getId())).willReturn(todoTeamList);
         // when
-        List<TodoTeamNameSimpleResponse> result = todoTeamGetUseCase.getTodoTeamName();
+        List<TodoTeamNameResponse> result = todoTeamGetUseCase.getTodoTeamName();
         // then
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result.size()).isEqualTo(todoTeamList.size());

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/CategoryController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/CategoryController.java
@@ -1,6 +1,6 @@
 package com.pawith.todopresentation;
 
-import com.pawith.todoapplication.dto.response.CategoryListResponse;
+import com.pawith.todoapplication.dto.response.CategoryInfoListResponse;
 import com.pawith.todoapplication.service.CategoryGetUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,7 +14,7 @@ public class CategoryController {
     private final CategoryGetUseCase categoryGetUseCase;
 
     @GetMapping("/teams/{todoTeamId}/category")
-    public CategoryListResponse getCategoryList(@PathVariable Long todoTeamId){
+    public CategoryInfoListResponse getCategoryList(@PathVariable Long todoTeamId){
         return categoryGetUseCase.getCategoryList(todoTeamId);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
@@ -1,8 +1,8 @@
 package com.pawith.todopresentation;
 
 import com.pawith.todoapplication.dto.request.AuthorityChangeRequest;
-import com.pawith.todoapplication.dto.response.ManageRegisterListResponse;
-import com.pawith.todoapplication.dto.response.RegisterListResponse;
+import com.pawith.todoapplication.dto.response.RegisterManageListResponse;
+import com.pawith.todoapplication.dto.response.RegisterInfoListResponse;
 import com.pawith.todoapplication.dto.response.RegisterTermResponse;
 import com.pawith.todoapplication.service.ChangeRegisterUseCase;
 import com.pawith.todoapplication.service.RegistersGetUseCase;
@@ -32,12 +32,12 @@ public class RegisterController {
     }
 
     @GetMapping("/{todoTeamId}/registers")
-    public RegisterListResponse getRegisters(@PathVariable Long todoTeamId){
+    public RegisterInfoListResponse getRegisters(@PathVariable Long todoTeamId){
         return registersGetUseCase.getRegisters(todoTeamId);
     }
 
     @GetMapping("/{todoTeamId}/registers/manage")
-    public ManageRegisterListResponse getRegistersForManage(@PathVariable Long todoTeamId){
+    public RegisterManageListResponse getRegistersForManage(@PathVariable Long todoTeamId){
         return registersGetUseCase.getManageRegisters(todoTeamId);
     }
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
@@ -30,7 +30,7 @@ public class TodoController {
     }
 
     @GetMapping("/{todoTeamId}/todos")
-    public SliceResponse<TodoHomeResponse> getTodos(@PathVariable Long todoTeamId, Pageable pageable) {
+    public SliceResponse<TodoInfoResponse> getTodos(@PathVariable Long todoTeamId, Pageable pageable) {
         return todoGetUseCase.getTodoListByTodoTeamId(todoTeamId, pageable);
     }
 
@@ -40,12 +40,12 @@ public class TodoController {
     }
 
     @GetMapping("/category/{categoryId}/todos")
-    public TodoListResponse getTodosAboutCategorySubTodo(@PathVariable Long categoryId, @RequestParam("moveDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)  LocalDate moveDate){
+    public CategorySubTodoListResponse getTodosAboutCategorySubTodo(@PathVariable Long categoryId, @RequestParam("moveDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)  LocalDate moveDate){
         return todoGetUseCase.getTodoListByCategoryId(categoryId, moveDate);
     }
 
     @GetMapping("/{todoTeamId}/todos/progress/compare")
-    public TodoRateCompareResponse getTodoWeekProgressCompare(@PathVariable Long todoTeamId){
+    public TodoProgressRateCompareResponse getTodoWeekProgressCompare(@PathVariable Long todoTeamId){
         return todoRateGetUseCase.getWeekProgressCompare(todoTeamId);
     }
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
@@ -2,10 +2,10 @@ package com.pawith.todopresentation;
 
 import com.pawith.commonmodule.slice.SliceResponse;
 import com.pawith.todoapplication.dto.request.TodoTeamCreateRequest;
-import com.pawith.todoapplication.dto.response.TodoTeamNameSimpleResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
-import com.pawith.todoapplication.dto.response.TodoTeamSimpleResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
 import com.pawith.todoapplication.service.TodoTeamCreateUseCase;
 import com.pawith.todoapplication.service.TodoTeamGetUseCase;
 import com.pawith.todoapplication.service.TodoTeamRandomCodeGetUseCase;
@@ -29,12 +29,8 @@ public class TodoTeamController {
     private final TodoTeamRandomCodeGetUseCase todoTeamRandomCodeGetUseCase;
     private final TodoTeamCreateUseCase todoTeamCreateUseCase;
 
-    /**
-     * 리팩터링 전 : 100명 동시 요청 평균 202ms
-     * <br>리팩터링 후 : 100명 동시 요청 평균
-     */
     @GetMapping
-    public SliceResponse<TodoTeamSimpleResponse> getTodoTeams(Pageable pageable) {
+    public SliceResponse<TodoTeamInfoResponse> getTodoTeams(Pageable pageable) {
         return todoTeamGetUseCase.getTodoTeams(PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by("id").descending()));
     }
 
@@ -56,7 +52,7 @@ public class TodoTeamController {
     }
 
     @GetMapping("/name")
-    public List<TodoTeamNameSimpleResponse> getTodoTeamName() {
+    public List<TodoTeamNameResponse> getTodoTeamName() {
         return todoTeamGetUseCase.getTodoTeamName();
     }
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/CategoryControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/CategoryControllerTest.java
@@ -3,7 +3,7 @@ package com.pawith.todopresentation;
 import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
 import com.pawith.todoapplication.dto.response.CategoryInfoResponse;
-import com.pawith.todoapplication.dto.response.CategoryListResponse;
+import com.pawith.todoapplication.dto.response.CategoryInfoListResponse;
 import com.pawith.todoapplication.service.CategoryGetUseCase;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -41,8 +41,8 @@ public class CategoryControllerTest extends BaseRestDocsTest {
         // given
         final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
         final List<CategoryInfoResponse> categoryListResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(CategoryInfoResponse.class, 2);
-        final CategoryListResponse categoryListResponse = new CategoryListResponse(categoryListResponses);
-        given(categoryGetUseCase.getCategoryList(testTeamId)).willReturn(categoryListResponse);
+        final CategoryInfoListResponse categoryInfoListResponse = new CategoryInfoListResponse(categoryListResponses);
+        given(categoryGetUseCase.getCategoryList(testTeamId)).willReturn(categoryInfoListResponse);
         MockHttpServletRequestBuilder request = get(CATEGORY_REQUEST_URL + "/{teamId}/category", testTeamId)
                 .header("Authorization", "Bearer accessToken");
         // when

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -92,9 +92,9 @@ class RegisterControllerTest extends BaseRestDocsTest {
     void getRegisters() throws Exception {
         //given
         final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
-        final List<RegisterSimpleInfoResponse> registerSimpleInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(RegisterSimpleInfoResponse.class, 10);
-        final RegisterListResponse registerListResponse = new RegisterListResponse(registerSimpleInfoResponses);
-        given(registersGetUseCase.getRegisters(todoTeamId)).willReturn(registerListResponse);
+        final List<RegisterInfoResponse> registerInfoRespons = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(RegisterInfoResponse.class, 10);
+        final RegisterInfoListResponse registerInfoListResponse = new RegisterInfoListResponse(registerInfoRespons);
+        given(registersGetUseCase.getRegisters(todoTeamId)).willReturn(registerInfoListResponse);
         MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}/registers",todoTeamId)
             .header("Authorization", "Bearer accessToken");
         //when
@@ -122,9 +122,9 @@ class RegisterControllerTest extends BaseRestDocsTest {
     void getManageRegisters() throws Exception {
         //given
         final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
-        final List<ManageRegisterInfoResponse> manageRegisterInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(ManageRegisterInfoResponse.class, 10);
-        final ManageRegisterListResponse manageRegisterListResponse = new ManageRegisterListResponse(manageRegisterInfoResponses);
-        given(registersGetUseCase.getManageRegisters(todoTeamId)).willReturn(manageRegisterListResponse);
+        final List<RegisterManageInfoResponse> registerManageInfoRespons = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(RegisterManageInfoResponse.class, 10);
+        final RegisterManageListResponse registerManageListResponse = new RegisterManageListResponse(registerManageInfoRespons);
+        given(registersGetUseCase.getManageRegisters(todoTeamId)).willReturn(registerManageListResponse);
         MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}/registers/manage",todoTeamId)
                 .header("Authorization", "Bearer accessToken");
         //when

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -79,13 +79,13 @@ public class TodoControllerTest extends BaseRestDocsTest {
         //given
         final PageRequest pageRequest = PageRequest.of(0, 6);
         final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
-        final List<TodoHomeResponse> todoHomeResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
-                .giveMeBuilder(TodoHomeResponse.class)
+        final List<TodoInfoResponse> todoRespons = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
+                .giveMeBuilder(TodoInfoResponse.class)
                 .set("todoId", Arbitraries.longs().greaterOrEqual(1L))
                 .set("task", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(5).ofMaxLength(10))
                 .set("status", FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeBuilder("COMPLETE"))
                 .sampleList(pageRequest.getPageSize());
-        final SliceImpl<TodoHomeResponse> slice = new SliceImpl(todoHomeResponses, pageRequest, true);
+        final SliceImpl<TodoInfoResponse> slice = new SliceImpl(todoRespons, pageRequest, true);
         given(todoGetUseCase.getTodoListByTodoTeamId(any(), any())).willReturn(SliceResponse.from(slice));
         MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/{todoTeamId}/todos", testTeamId)
                 .queryParam("page", String.valueOf(pageRequest.getPageNumber()))
@@ -157,8 +157,8 @@ public class TodoControllerTest extends BaseRestDocsTest {
             .set("status", FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeBuilder("COMPLETE"))
             .set("assignNames", assignUserInfoResponses)
             .sampleList(2);
-        final TodoListResponse todoListResponse = new TodoListResponse(categorySubTodoResponses);
-        given(todoGetUseCase.getTodoListByCategoryId(any(), any())).willReturn(todoListResponse);
+        final CategorySubTodoListResponse categorySubTodoListResponse = new CategorySubTodoListResponse(categorySubTodoResponses);
+        given(todoGetUseCase.getTodoListByCategoryId(any(), any())).willReturn(categorySubTodoListResponse);
         MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/category/{categoryId}/todos", testCategoryId)
                 .queryParam("moveDate", testMoveDate.toString())
                 .header("Authorization", "Bearer accessToken");
@@ -192,7 +192,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
     void getWeekProgressCompare() throws Exception {
         //given
         final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
-        given(todoRateGetUseCase.getWeekProgressCompare(testTeamId)).willReturn(new TodoRateCompareResponse(true, false));
+        given(todoRateGetUseCase.getWeekProgressCompare(testTeamId)).willReturn(new TodoProgressRateCompareResponse(true, false));
         MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/{todoTeamId}/todos/progress/compare", testTeamId)
                 .header("Authorization", "Bearer accessToken");
         //when

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -3,10 +3,10 @@ package com.pawith.todopresentation;
 import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.commonmodule.slice.SliceResponse;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
-import com.pawith.todoapplication.dto.response.TodoTeamNameSimpleResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
-import com.pawith.todoapplication.dto.response.TodoTeamSimpleResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
 import com.pawith.todoapplication.service.TodoTeamCreateUseCase;
 import com.pawith.todoapplication.service.TodoTeamGetUseCase;
 import com.pawith.todoapplication.service.TodoTeamRandomCodeGetUseCase;
@@ -69,14 +69,14 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
     void getTodoTeams() throws Exception {
         //given
         final PageRequest pageRequest = PageRequest.of(0, 10);
-        final List<TodoTeamSimpleResponse> todoTeamSimpleResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
-            .giveMeBuilder(TodoTeamSimpleResponse.class)
+        final List<TodoTeamInfoResponse> myPageTodoTeamRespons = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
+            .giveMeBuilder(TodoTeamInfoResponse.class)
             .set("teamId", Arbitraries.longs().greaterOrEqual(1L))
             .set("registerPeriod", Arbitraries.integers().greaterOrEqual(1))
             .set("teamName", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(5).ofMaxLength(10))
             .sampleList(pageRequest.getPageSize());
-        todoTeamSimpleResponses.sort(((o1, o2) -> (int) (o2.getTeamId() - o1.getTeamId())));
-        final SliceImpl<TodoTeamSimpleResponse> slice = new SliceImpl(todoTeamSimpleResponses, pageRequest, true);
+        myPageTodoTeamRespons.sort(((o1, o2) -> (int) (o2.getTeamId() - o1.getTeamId())));
+        final SliceImpl<TodoTeamInfoResponse> slice = new SliceImpl(myPageTodoTeamRespons, pageRequest, true);
         given(todoTeamGetUseCase.getTodoTeams(any())).willReturn(SliceResponse.from(slice));
         MockHttpServletRequestBuilder request = get(TODO_TEAM_REQUEST_URL)
             .queryParam("page", String.valueOf(pageRequest.getPageNumber()))
@@ -190,8 +190,8 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
     @DisplayName("가입한 팀 조회 API 테스트")
     void getTodoTeamName() throws Exception {
         //given
-        final List<TodoTeamNameSimpleResponse> todoTeamNameSimpleResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(TodoTeamNameSimpleResponse.class, 5);
-        given(todoTeamGetUseCase.getTodoTeamName()).willReturn(todoTeamNameSimpleResponses);
+        final List<TodoTeamNameResponse> todoTeamNameRespons = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(TodoTeamNameResponse.class, 5);
+        given(todoTeamGetUseCase.getTodoTeamName()).willReturn(todoTeamNameRespons);
         MockHttpServletRequestBuilder request = get(TODO_TEAM_REQUEST_URL + "/name")
             .header("Authorization", "Bearer accessToken");
         //when


### PR DESCRIPTION
## 작업사항
- DTO 네이밍 통일성 있고 파악하기 쉽게 수정했습니다.

## 변경로직
- 내용을 적어주세요.

## 참고자료
1. 엔티티 + 행위 + (Request|Response) 형식
2. 조회의 경우 행위 다음 Info 추가(ex : /teams/{todoTeamId}/register: RegisterInfoResponse)



