### PR TITLE
Pet 146 refactor : TodoTeam 탈퇴시 Register 삭제에서 탈퇴 필드 값 변경하는 방식으로 수정

### DIFF
--- a/Common-Module/src/testFixtures/java/com/pawith/commonmodule/utils/FixtureMonkeyUtils.java
+++ b/Common-Module/src/testFixtures/java/com/pawith/commonmodule/utils/FixtureMonkeyUtils.java
@@ -1,6 +1,7 @@
 package com.pawith.commonmodule.utils;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.FixtureMonkeyBuilder;
 import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.introspector.JavaTypeArbitraryGenerator;
@@ -11,28 +12,22 @@ public class FixtureMonkeyUtils {
     private FixtureMonkeyUtils() {
     }
 
-    private static final FixtureMonkey CONSTRUCT_BASED_FIXTURE_MONKEY = FixtureMonkey.builder()
+    private static final FixtureMonkey CONSTRUCT_BASED_FIXTURE_MONKEY = setupJavaType(FixtureMonkey.builder())
         .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
         .defaultNotNull(true)
         .build();
 
-    private static final FixtureMonkey BUILDER_BASED_FIXTURE_MONKEY = FixtureMonkey.builder()
+    private static final FixtureMonkey BUILDER_BASED_FIXTURE_MONKEY = setupJavaType(FixtureMonkey.builder())
         .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
         .defaultNotNull(true)
         .build();
 
-    private static final FixtureMonkey REFLECTION_BASED_FIXTURE_MONKEY = FixtureMonkey.builder()
+    private static final FixtureMonkey REFLECTION_BASED_FIXTURE_MONKEY = setupJavaType(FixtureMonkey.builder())
         .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
         .defaultNotNull(true)
         .build();
 
-    private static final FixtureMonkey JAVA_TYPE_BASED_FIXTURE_MONKEY = FixtureMonkey.builder()
-        .javaTypeArbitraryGenerator(new JavaTypeArbitraryGenerator() {
-            @Override
-            public StringArbitrary strings() {
-                return Arbitraries.strings().alpha().numeric().ofMinLength(1).ofMaxLength(10);
-            }
-        })
+    private static final FixtureMonkey JAVA_TYPE_BASED_FIXTURE_MONKEY = setupJavaType(FixtureMonkey.builder())
         .defaultNotNull(true)
         .build();
 
@@ -53,4 +48,13 @@ public class FixtureMonkeyUtils {
     }
 
 
+    private static FixtureMonkeyBuilder setupJavaType(FixtureMonkeyBuilder builder){
+        return builder
+            .javaTypeArbitraryGenerator(new JavaTypeArbitraryGenerator() {
+                @Override
+                public StringArbitrary strings() {
+                    return Arbitraries.strings().alpha().numeric().ofMinLength(1).ofMaxLength(10);
+                }
+            });
+    }
 }

--- a/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/command/feign/response/KakaoUserInfo.java
+++ b/Domain-Module/Auth-Module/Auth-Application/src/main/java/com/pawith/authapplication/service/command/feign/response/KakaoUserInfo.java
@@ -17,6 +17,8 @@ public class KakaoUserInfo {
     private static final String PROFILE = "profile";
     @JsonAlias("kakao_account")
     private Map<String, Object> kakaoAccount;
+
+    @SuppressWarnings("unchecked")
     public String getNickname(){
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get(PROFILE);
         return (String) profile.get(NAME);

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoCreateUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoCreateUseCase.java
@@ -28,9 +28,9 @@ public class TodoCreateUseCase {
 
     public void createTodo(TodoCreateRequest request) {
         final Category category = categoryQueryService.findCategoryById(request.getCategoryId());
-        Todo todo = TodoMapper.mapToTodo(request, category);
+        final Todo todo = TodoMapper.mapToTodo(request, category);
         todoSaveService.saveTodoEntity(todo);
-        ListIterator<Register> registerListIterator = registerQueryService.findAllRegisterByIds(request.getRegisterIds()).listIterator();
+        ListIterator<Register> registerListIterator = registerQueryService.findAllRegistersByIds(request.getRegisterIds()).listIterator();
         request.getRegisterIds().forEach(registerId -> {
             assignSaveService.saveAssignEntity(new Assign(todo, registerListIterator.next()));
         });

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -47,7 +47,8 @@ public class TodoGetUseCase {
 
 
     public CategorySubTodoListResponse getTodoListByCategoryId(Long categoryId, LocalDate moveDate) {
-        final Map<Long, User> userMap = userQueryService.findUserMapByIds(registerQueryService::findUserIdsByCategoryId, categoryId);
+        final List<Long> userIds = registerQueryService.findUserIdsByCategoryId(categoryId);
+        final Map<Long, User> userMap = userQueryService.findUserMapByIds(userIds);
         final Map<Todo, List<Register>> groupByTodo = getTodoMap(categoryId, moveDate);
         final ArrayList<CategorySubTodoResponse> todoMainResponses = new ArrayList<>();
         for (Todo todo : groupByTodo.keySet()) {

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/UnregisterUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/UnregisterUseCase.java
@@ -2,7 +2,6 @@ package com.pawith.todoapplication.service;
 
 import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.tododomain.entity.Register;
-import com.pawith.tododomain.service.RegisterDeleteService;
 import com.pawith.tododomain.service.RegisterQueryService;
 import com.pawith.userdomain.entity.User;
 import com.pawith.userdomain.utils.UserUtils;
@@ -15,11 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class UnregisterUseCase {
     private final UserUtils userUtils;
     private final RegisterQueryService registerQueryService;
-    private final RegisterDeleteService registerDeleteService;
 
     public void unregisterTodoTeam(final Long todoTeamId) {
         final User user = userUtils.getAccessUser();
         final Register register = registerQueryService.findRegisterByTodoTeamIdAndUserId(todoTeamId, user.getId());
-        registerDeleteService.deleteRegister(register);
+        register.unregister();
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Register.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Register.java
@@ -1,15 +1,21 @@
 package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.Arrays;
 
 @Entity
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE register SET is_deleted = true WHERE register_id = ?")
+@Where(clause = "is_deleted = false")
 public class Register extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,6 +30,10 @@ public class Register extends BaseEntity {
     private TodoTeam todoTeam;
 
     private Long userId;
+
+    private Boolean isDeleted=Boolean.FALSE;
+
+    private Boolean isRegistered=Boolean.TRUE;
 
     @Builder
     public Register(Authority authority, TodoTeam todoTeam, Long userId) {
@@ -41,5 +51,9 @@ public class Register extends BaseEntity {
     private boolean isValidAuthority(String authority) {
         return Arrays.stream(Authority.values())
                 .anyMatch(enumValue -> enumValue.name().equals(authority));
+    }
+
+    public void unregister(){
+        this.isRegistered = Boolean.FALSE;
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
@@ -13,27 +13,26 @@ import java.util.Optional;
 
 public interface RegisterRepository extends JpaRepository<Register, Long> {
 
-    @Query("select r from Register r join fetch r.todoTeam where r.userId = :userId")
+    @Query("select r from Register r join fetch r.todoTeam where r.userId = :userId and r.isRegistered = true")
     Slice<Register> findAllByUserId(Long userId, Pageable pageable);
-
-    Optional<Register> findByTodoTeamIdAndUserId(Long todoTeamId, Long userId);
-
-    Optional<Register> findByTodoTeamIdAndAuthority(Long todoTeamId, Authority authority);
-
-    @Query("select r from Register r join Category c on c.id = :categoryId where c.todoTeam.id= r.todoTeam.id")
-    List<Register> findAllByCategoryId(Long categoryId);
-
-    Boolean existsByTodoTeamIdAndUserId(Long todoTeamId, Long userId);
 
     List<Register> findAllByTodoTeamId(Long todoTeamId);
 
     @Query("select r from Register r where r.id in :ids")
     List<Register> findAllByIds(@Param("ids") List<Long> ids);
 
-    @Query("select r from Register r " +
-            "join Assign a on a.id=:todoId " +
-            "where a.register.id = r.id")
+    @Query("select r from Register r join Assign a on a.id=:todoId where a.register.id = r.id")
     List<Register> findByTodoId(Long todoId);
 
+    @Query("select r from Register r join Category c on c.id = :categoryId where c.todoTeam.id= r.todoTeam.id")
+    List<Register> findAllByCategoryId(Long categoryId);
+
+    Optional<Register> findByTodoTeamIdAndUserId(Long todoTeamId, Long userId);
+
+    Optional<Register> findByTodoTeamIdAndAuthority(Long todoTeamId, Authority authority);
+
+    @Query("select count(r) from Register r where r.todoTeam.id = :todoTeamId and r.isRegistered = true")
     Integer countByTodoTeamId(Long todoTeamId);
+
+    Boolean existsByTodoTeamIdAndUserIdAndIsRegistered(Long todoTeamId, Long userId, boolean isRegistered);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterSaveService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterSaveService.java
@@ -34,7 +34,7 @@ public class RegisterSaveService {
     }
 
     private void checkAlreadyRegisterTodoTeam(TodoTeam todoTeam, Long userId) {
-        if(registerRepository.existsByTodoTeamIdAndUserId(todoTeam.getId(), userId)){
+        if(registerRepository.existsByTodoTeamIdAndUserIdAndIsRegistered(todoTeam.getId(), userId, true)){
             throw new AlreadyRegisterTodoTeamException(Error.ALREADY_REGISTER_TODO_TEAM);
         }
     }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/test/java/com/pawith/tododomain/service/RegisterQueryServiceTest.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/test/java/com/pawith/tododomain/service/RegisterQueryServiceTest.java
@@ -2,11 +2,11 @@ package com.pawith.tododomain.service;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.pawith.commonmodule.UnitTestConfig;
-import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
 import com.pawith.tododomain.entity.Authority;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.exception.NotRegisterUserException;
 import com.pawith.tododomain.repository.RegisterRepository;
+import com.pawith.tododomain.utils.RegisterTestFixtureEntityUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -44,7 +44,7 @@ class RegisterQueryServiceTest {
         //given
         final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
         final Long userId = FixtureMonkey.create().giveMeOne(Long.class);
-        final Register mockRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(Register.class);
+        final Register mockRegister = RegisterTestFixtureEntityUtils.getRegisterEntity();
         given(registerRepository.findByTodoTeamIdAndUserId(todoTeamId, userId)).willReturn(Optional.of(mockRegister));
         //when
         Register result = registerQueryService.findRegisterByTodoTeamIdAndUserId(todoTeamId, userId);
@@ -71,7 +71,7 @@ class RegisterQueryServiceTest {
         //given
         final Long userId = FixtureMonkey.create().giveMeOne(Long.class);
         final PageRequest pageRequest = PageRequest.of(0, 10);
-        final List<Register> mockRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(Register.class, 10);
+        final List<Register> mockRegister = RegisterTestFixtureEntityUtils.getRegisterEntityList(pageRequest.getPageSize());
         SliceImpl<Register> mockSlice = new SliceImpl<>(mockRegister, pageRequest, true);
         given(registerRepository.findAllByUserId(userId,pageRequest)).willReturn(mockSlice);
         //when
@@ -85,7 +85,7 @@ class RegisterQueryServiceTest {
     void findByTodoTeamIdAndAuthority() {
         //given
         final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
-        final Register mockRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(Register.class);
+        final Register mockRegister = RegisterTestFixtureEntityUtils.getRegisterEntity();
         given(registerRepository.findByTodoTeamIdAndAuthority(todoTeamId, Authority.PRESIDENT)).willReturn(Optional.of(mockRegister));
         //when
         Register result = registerQueryService.findPresidentRegisterByTodoTeamId(todoTeamId);
@@ -110,10 +110,10 @@ class RegisterQueryServiceTest {
     void findAllRegisterByIds() {
         //given
         final List<Long> registerIds = FixtureMonkey.create().giveMe(Long.class, 10);
-        final List<Register> mockRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(Register.class, 10);
+        final List<Register> mockRegister = RegisterTestFixtureEntityUtils.getRegisterEntityList(registerIds.size());
         given(registerRepository.findAllByIds(registerIds)).willReturn(mockRegister);
         //when
-        List<Register> result = registerQueryService.findAllRegisterByIds(registerIds);
+        List<Register> result = registerQueryService.findAllRegistersByIds(registerIds);
         //then
         Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(mockRegister);
     }
@@ -124,11 +124,10 @@ class RegisterQueryServiceTest {
         //given
         final Long userId = FixtureMonkey.create().giveMeOne(Long.class);
         final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
-        final List<Register> mockRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(Register.class, 10);
-        given(registerRepository.existsByTodoTeamIdAndUserId(todoTeamId, userId)).willReturn(true);
+        final List<Register> mockRegister = RegisterTestFixtureEntityUtils.getRegisterEntityList(5);
         given(registerRepository.findAllByTodoTeamId(todoTeamId)).willReturn(mockRegister);
         //when
-        List<Register> result = registerQueryService.findAllRegisters(userId, todoTeamId);
+        List<Register> result = registerQueryService.findAllRegistersByTodoTeamId(todoTeamId);
         //then
         Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(mockRegister);
     }
@@ -139,9 +138,8 @@ class RegisterQueryServiceTest {
         //given
         final Long userId = FixtureMonkey.create().giveMeOne(Long.class);
         final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
-        given(registerRepository.existsByTodoTeamIdAndUserId(todoTeamId, userId)).willReturn(false);
         //when
-        List<Register> result = registerQueryService.findAllRegisters(userId, todoTeamId);
+        List<Register> result = registerQueryService.findAllRegistersByTodoTeamId(todoTeamId);
         //then
         Assertions.assertThat(result).isEmpty();
     }
@@ -151,10 +149,10 @@ class RegisterQueryServiceTest {
     void findAllRegisterByTodoId() {
         //given
         final Long todoId = FixtureMonkey.create().giveMeOne(Long.class);
-        final List<Register> mockRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(Register.class, 10);
+        final List<Register> mockRegister = RegisterTestFixtureEntityUtils.getRegisterEntityList(5);
         given(registerRepository.findByTodoId(todoId)).willReturn(mockRegister);
         //when
-        List<Register> result = registerQueryService.findAllRegisterByTodoId(todoId);
+        List<Register> result = registerQueryService.findAllRegistersByTodoId(todoId);
         //then
         Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(mockRegister);
     }
@@ -177,7 +175,7 @@ class RegisterQueryServiceTest {
     void findUserIdsByCategoryId() {
         //given
         final Long categoryId = FixtureMonkey.create().giveMeOne(Long.class);
-        final List<Register> mockRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(Register.class, 10);
+        final List<Register> mockRegister = RegisterTestFixtureEntityUtils.getRegisterEntityList(5);
         given(registerRepository.findAllByCategoryId(categoryId)).willReturn(mockRegister);
         //when
         List<Long> result = registerQueryService.findUserIdsByCategoryId(categoryId);
@@ -191,7 +189,7 @@ class RegisterQueryServiceTest {
         //given
         final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
         final Long userId = FixtureMonkey.create().giveMeOne(Long.class);
-        final Register mockRegister = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(Register.class);
+        final Register mockRegister = RegisterTestFixtureEntityUtils.getRegisterEntity();
         final LocalDate mockDate = LocalDate.now();
         given(registerRepository.findByTodoTeamIdAndUserId(todoTeamId, userId)).willReturn(Optional.of(mockRegister));
         //when

--- a/Domain-Module/Todo-Module/Todo-Domain/src/test/java/com/pawith/tododomain/service/RegisterSaveServiceTest.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/test/java/com/pawith/tododomain/service/RegisterSaveServiceTest.java
@@ -36,7 +36,7 @@ class RegisterSaveServiceTest {
         //given
         final TodoTeam todoTeam = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(TodoTeam.class);
         final Long userId = FixtureMonkey.create().giveMeOne(Long.class);
-        given(registerRepository.existsByTodoTeamIdAndUserId(todoTeam.getId(), userId)).willReturn(false);
+        given(registerRepository.existsByTodoTeamIdAndUserIdAndIsRegistered(todoTeam.getId(), userId,true)).willReturn(false);
         //when
         registerSaveService.saveRegisterAboutMember(todoTeam, userId);
         //then
@@ -49,7 +49,7 @@ class RegisterSaveServiceTest {
         //given
         final TodoTeam todoTeam = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(TodoTeam.class);
         final Long userId = FixtureMonkey.create().giveMeOne(Long.class);
-        given(registerRepository.existsByTodoTeamIdAndUserId(todoTeam.getId(), userId)).willReturn(false);
+        given(registerRepository.existsByTodoTeamIdAndUserIdAndIsRegistered(todoTeam.getId(), userId,true)).willReturn(false);
         //when
         registerSaveService.saveRegisterAboutPresident(todoTeam, userId);
         //then
@@ -62,7 +62,7 @@ class RegisterSaveServiceTest {
         //given
         final TodoTeam todoTeam = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeOne(TodoTeam.class);
         final Long userId = FixtureMonkey.create().giveMeOne(Long.class);
-        given(registerRepository.existsByTodoTeamIdAndUserId(todoTeam.getId(), userId)).willReturn(true);
+        given(registerRepository.existsByTodoTeamIdAndUserIdAndIsRegistered(todoTeam.getId(), userId,true)).willReturn(true);
         //when
         //then
         Assertions.assertThatCode(() -> registerSaveService.saveRegisterAboutMember(todoTeam, userId))

--- a/Domain-Module/Todo-Module/Todo-Domain/src/test/java/com/pawith/tododomain/utils/RegisterTestFixtureEntityUtils.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/test/java/com/pawith/tododomain/utils/RegisterTestFixtureEntityUtils.java
@@ -1,0 +1,38 @@
+package com.pawith.tododomain.utils;
+
+import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import com.pawith.tododomain.entity.Register;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RegisterTestFixtureEntityUtils {
+
+    public static Register getRegisterEntity(){
+        return FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeBuilder(Register.class)
+            .set("isRegistered", true)
+            .sample();
+    }
+
+    public static Register getRegisterEntityWithUnregistered(){
+        return FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeBuilder(Register.class)
+            .set("isRegistered", false)
+            .sample();
+    }
+
+    public static List<Register> getRegisterEntityList(int size){
+        return FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeBuilder(Register.class)
+            .set("isRegistered", true)
+            .sampleList(size);
+    }
+
+    public static List<Register> getRegisterEntityListWithUnregistered(int size){
+        return FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeBuilder(Register.class)
+            .set("isRegistered", false)
+            .sampleList(size);
+    }
+
+
+}

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -34,7 +34,7 @@ operation::todo-team-controller-test/get-todo-team-code[snippets='http-request,p
 [[Todo-Team-Code로-조회]]
 === Todo Team Code로 Todo Team 조회
 
-operation::todo-team-controller-test/get-todo-team-by-code[snippets='http-request,request-parameters,request-headers,http-response,response-fields']
+operation::todo-team-controller-test/get-todo-team-by-code[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 
 [[Todo-API]]
 == Todo API

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/service/UserQueryService.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/service/UserQueryService.java
@@ -36,8 +36,7 @@ public class UserQueryService {
         return findUser(userRepository::findById, userId);
     }
 
-    public <T> Map<Long,User> findUserMapByIds(Function<T, List<Long>> userIdsReturnMethod, T specificationData){
-        final List<Long> userIds = userIdsReturnMethod.apply(specificationData);
+    public <T> Map<Long,User> findUserMapByIds(List<Long> userIds){
         return userRepository.findAllByIds(userIds)
             .stream()
             .collect(Collectors.toMap(User::getId, Function.identity()));


### PR DESCRIPTION
## 작업사항
- TodoTeam 탈퇴시 Register 삭제에서 탈퇴 필드 값(isRegistered) 변경하는 방식으로 수정
- Register 엔티티에 탈퇴 필드 값 추가로 검색 메소드에 탈퇴 여부 필터링 메소드 추가
- Register 엔티티에 탈퇴 필드 값 추가로 (탈퇴/비탈퇴) 상태 가지는 테스트 객체 생성 유틸 클래스 추가
- UserQueryService의 findUserMapByIds 메소드 파라미터 함수형 인터페이스에서 userId 리스트 받도록 수정

## 변경로직
- UserQueryService의 findUserMapByIds 메소드 파라미터 함수형 인터페이스에서 userId 리스트 받도록 수정에 따른 메소드 및 테스트 수정

## 참고자료
- 내용을 적어주세요.



