### PR TITLE
Pet 152 refactor : Todo 전반적인 로직 수정 

### DIFF
--- a/Common-Module/src/main/java/com/pawith/commonmodule/event/TodoCompletionCheckEvent.java
+++ b/Common-Module/src/main/java/com/pawith/commonmodule/event/TodoCompletionCheckEvent.java
@@ -1,0 +1,10 @@
+package com.pawith.commonmodule.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TodoCompletionCheckEvent {
+    private final Long todoId;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/AssignUserInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/AssignUserInfoResponse.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class AssignUserInfoResponse {
     private final Long assigneeId;
     private final String assigneeName;
+    private final String completionStatus;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/AssignUserInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/AssignUserInfoResponse.java
@@ -1,5 +1,6 @@
 package com.pawith.todoapplication.dto.response;
 
+import com.pawith.tododomain.entity.CompletionStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,5 +9,5 @@ import lombok.Getter;
 public class AssignUserInfoResponse {
     private final Long assigneeId;
     private final String assigneeName;
-    private final String completionStatus;
+    private final CompletionStatus completionStatus;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoResponse.java
@@ -1,5 +1,6 @@
 package com.pawith.todoapplication.dto.response;
 
+import com.pawith.tododomain.entity.CompletionStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,6 +14,6 @@ import java.util.List;
 public class CategorySubTodoResponse {
     private Long todoId;
     private String task;
-    private String completionStatus;
+    private CompletionStatus completionStatus;
     private List<AssignUserInfoResponse> assignNames;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoResponse.java
@@ -13,6 +13,6 @@ import java.util.List;
 public class CategorySubTodoResponse {
     private Long todoId;
     private String task;
-    private String status;
+    private String completionStatus;
     private List<AssignUserInfoResponse> assignNames;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoCompletionResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoCompletionResponse.java
@@ -1,0 +1,13 @@
+package com.pawith.todoapplication.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class TodoCompletionResponse {
+    private String completionStatus;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoCompletionResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoCompletionResponse.java
@@ -1,5 +1,6 @@
 package com.pawith.todoapplication.dto.response;
 
+import com.pawith.tododomain.entity.CompletionStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,5 +10,5 @@ import lombok.ToString;
 @ToString
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class TodoCompletionResponse {
-    private String completionStatus;
+    private CompletionStatus completionStatus;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/TodoCompletionCheckOnTodoHandler.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/TodoCompletionCheckOnTodoHandler.java
@@ -1,0 +1,34 @@
+package com.pawith.todoapplication.handler;
+
+import com.pawith.commonmodule.event.TodoCompletionCheckEvent;
+import com.pawith.tododomain.entity.Assign;
+import com.pawith.tododomain.entity.CompletionStatus;
+import com.pawith.tododomain.entity.Todo;
+import com.pawith.tododomain.service.AssignQueryService;
+import com.pawith.tododomain.service.TodoQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class TodoCompletionCheckOnTodoHandler {
+    private final AssignQueryService assignQueryService;
+    private final TodoQueryService todoQueryService;
+
+    @EventListener
+    public void changeAssignStatus(TodoCompletionCheckEvent todoCompletionCheckEvent){
+        final List<Assign> assigns = assignQueryService.findAllAssignByTodoId(todoCompletionCheckEvent.getTodoId());
+        final Todo todo = todoQueryService.findTodoByTodoId(todoCompletionCheckEvent.getTodoId());
+        CompletionStatus newStatus = assigns.stream()
+                .allMatch(assign -> assign.getCompletionStatus() == CompletionStatus.COMPLETE)
+                ? CompletionStatus.COMPLETE
+                : CompletionStatus.INCOMPLETE;
+        todo.updateCompletionStatus(newStatus);
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/TodoCompletionCheckOnTodoHandler.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/TodoCompletionCheckOnTodoHandler.java
@@ -22,7 +22,7 @@ public class TodoCompletionCheckOnTodoHandler {
     private final TodoQueryService todoQueryService;
 
     @EventListener
-    public void changeAssignStatus(TodoCompletionCheckEvent todoCompletionCheckEvent){
+    public void changeTodoStatus(TodoCompletionCheckEvent todoCompletionCheckEvent){
         final List<Assign> assigns = assignQueryService.findAllAssignByTodoId(todoCompletionCheckEvent.getTodoId());
         final Todo todo = todoQueryService.findTodoByTodoId(todoCompletionCheckEvent.getTodoId());
         CompletionStatus newStatus = assigns.stream()

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/TodoCompletionCheckOnTodoHandler.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/TodoCompletionCheckOnTodoHandler.java
@@ -1,6 +1,6 @@
 package com.pawith.todoapplication.handler;
 
-import com.pawith.commonmodule.event.TodoCompletionCheckEvent;
+import com.pawith.todoapplication.handler.event.TodoCompletionCheckEvent;
 import com.pawith.tododomain.entity.Assign;
 import com.pawith.tododomain.entity.CompletionStatus;
 import com.pawith.tododomain.entity.Todo;

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/event/TodoCompletionCheckEvent.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/event/TodoCompletionCheckEvent.java
@@ -1,4 +1,4 @@
-package com.pawith.commonmodule.event;
+package com.pawith.todoapplication.handler.event;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/AssignChangeUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/AssignChangeUseCase.java
@@ -1,7 +1,7 @@
 package com.pawith.todoapplication.service;
 
 import com.pawith.commonmodule.annotation.ApplicationService;
-import com.pawith.commonmodule.event.TodoCompletionCheckEvent;
+import com.pawith.todoapplication.handler.event.TodoCompletionCheckEvent;
 import com.pawith.tododomain.entity.Assign;
 import com.pawith.tododomain.entity.Todo;
 import com.pawith.tododomain.service.AssignQueryService;

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/AssignChangeUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/AssignChangeUseCase.java
@@ -1,0 +1,32 @@
+package com.pawith.todoapplication.service;
+
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.commonmodule.event.TodoCompletionCheckEvent;
+import com.pawith.tododomain.entity.Assign;
+import com.pawith.tododomain.entity.Todo;
+import com.pawith.tododomain.service.AssignQueryService;
+import com.pawith.tododomain.service.TodoQueryService;
+import com.pawith.userdomain.entity.User;
+import com.pawith.userdomain.utils.UserUtils;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional
+public class AssignChangeUseCase {
+
+    private final AssignQueryService assignQueryService;
+    private final TodoQueryService todoQueryService;
+    private final UserUtils userUtils;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public void changeAssignStatus(Long todoId){
+        final Todo todo = todoQueryService.findTodoByTodoId(todoId);
+        final User user = userUtils.getAccessUser();
+        final Assign assign = assignQueryService.findAssignByTodoIdAndUserId(todo.getId(), user.getId());
+        assign.updateCompletionStatus();
+        applicationEventPublisher.publishEvent(new TodoCompletionCheckEvent(todo.getId()));
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -3,6 +3,7 @@ package com.pawith.todoapplication.service;
 import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.commonmodule.slice.SliceResponse;
 import com.pawith.todoapplication.dto.response.AssignUserInfoResponse;
+import com.pawith.todoapplication.dto.response.TodoCompletionResponse;
 import com.pawith.todoapplication.dto.response.TodoInfoResponse;
 import com.pawith.todoapplication.dto.response.CategorySubTodoResponse;
 import com.pawith.todoapplication.dto.response.CategorySubTodoListResponse;
@@ -60,6 +61,11 @@ public class TodoGetUseCase {
             todoMainResponses.add(new CategorySubTodoResponse(todo.getId(), todo.getDescription(), todo.getCompletionStatus().name(), assignUserInfoResponses));
         }
         return new CategorySubTodoListResponse(todoMainResponses);
+    }
+
+    public TodoCompletionResponse getTodoCompletion(Long todoId) {
+        final Todo todo = todoQueryService.findTodoByTodoId(todoId);
+        return new TodoCompletionResponse(todo.getCompletionStatus().name());
     }
 
     private Map<Todo, List<Register>> getTodoMap(Long categoryId, LocalDate moveDate) {

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -15,17 +15,16 @@ import com.pawith.tododomain.service.TodoQueryService;
 import com.pawith.userdomain.entity.User;
 import com.pawith.userdomain.service.UserQueryService;
 import com.pawith.userdomain.utils.UserUtils;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
 
 @ApplicationService
 @RequiredArgsConstructor
@@ -41,7 +40,7 @@ public class TodoGetUseCase {
     public SliceResponse<TodoInfoResponse> getTodoListByTodoTeamId(final Long todoTeamId, final Pageable pageable) {
         final User user = userUtils.getAccessUser();
         final Slice<Todo> todoList = todoQueryService.findTodayTodoSlice(user.getId(), todoTeamId, pageable);
-        Slice<TodoInfoResponse> todoHomeResponseSlice = todoList.map(todo -> new TodoInfoResponse(todo.getId(), todo.getDescription(), todo.getTodoStatus().name()));
+        Slice<TodoInfoResponse> todoHomeResponseSlice = todoList.map(todo -> new TodoInfoResponse(todo.getId(), todo.getDescription(), todo.getCompletionStatus().name()));
         return SliceResponse.from(todoHomeResponseSlice);
     }
 
@@ -58,7 +57,7 @@ public class TodoGetUseCase {
                 final User findUser = userMap.get(register.getUserId());
                 assignUserInfoResponses.add(new AssignUserInfoResponse(findUser.getId(), findUser.getNickname()));
             }
-            todoMainResponses.add(new CategorySubTodoResponse(todo.getId(), todo.getDescription(), todo.getTodoStatus().name(), assignUserInfoResponses));
+            todoMainResponses.add(new CategorySubTodoResponse(todo.getId(), todo.getDescription(), todo.getCompletionStatus().name(), assignUserInfoResponses));
         }
         return new CategorySubTodoListResponse(todoMainResponses);
     }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -50,13 +50,16 @@ public class TodoGetUseCase {
         final List<Long> userIds = registerQueryService.findUserIdsByCategoryId(categoryId);
         final Map<Long, User> userMap = userQueryService.findUserMapByIds(userIds);
         final Map<Todo, List<Register>> groupByTodo = getTodoMap(categoryId, moveDate);
+        final Map<Register,Assign> assignMap = assignQueryService.findAllAssignByCategoryIdAndScheduledDate(categoryId, moveDate)
+            .stream()
+            .collect(Collectors.toMap(Assign::getRegister, assign -> assign));
         final ArrayList<CategorySubTodoResponse> todoMainResponses = new ArrayList<>();
         for (Todo todo : groupByTodo.keySet()) {
             final List<Register> registers = groupByTodo.get(todo);
             ArrayList<AssignUserInfoResponse> assignUserInfoResponses = new ArrayList<>();
             for (Register register : registers) {
                 final User findUser = userMap.get(register.getUserId());
-                assignUserInfoResponses.add(new AssignUserInfoResponse(findUser.getId(), findUser.getNickname()));
+                assignUserInfoResponses.add(new AssignUserInfoResponse(findUser.getId(), findUser.getNickname(), assignMap.get(register).getCompletionStatus().name()));
             }
             todoMainResponses.add(new CategorySubTodoResponse(todo.getId(), todo.getDescription(), todo.getCompletionStatus().name(), assignUserInfoResponses));
         }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -60,16 +60,16 @@ public class TodoGetUseCase {
             for (Assign assign : assigns) {
                 final Register register = registerMap.get(assign.getRegister().getId());
                 final User findUser = userMap.get(register.getUserId());
-                assignUserInfoResponses.add(new AssignUserInfoResponse(findUser.getId(), findUser.getNickname(), assign.getCompletionStatus().name()));
+                assignUserInfoResponses.add(new AssignUserInfoResponse(findUser.getId(), findUser.getNickname(), assign.getCompletionStatus()));
             }
-            todoMainResponses.add(new CategorySubTodoResponse(todo.getId(), todo.getDescription(), todo.getCompletionStatus().name(), assignUserInfoResponses));
+            todoMainResponses.add(new CategorySubTodoResponse(todo.getId(), todo.getDescription(), todo.getCompletionStatus(), assignUserInfoResponses));
         }
         return new CategorySubTodoListResponse(todoMainResponses);
     }
 
     public TodoCompletionResponse getTodoCompletion(Long todoId) {
         final Todo todo = todoQueryService.findTodoByTodoId(todoId);
-        return new TodoCompletionResponse(todo.getCompletionStatus().name());
+        return new TodoCompletionResponse(todo.getCompletionStatus());
     }
 
     private Map<Todo, List<Assign>> getTodoMap(Long categoryId, LocalDate moveDate) {

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/handler/TodoCompletionCheckOnTodoHandlerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/handler/TodoCompletionCheckOnTodoHandlerTest.java
@@ -1,0 +1,84 @@
+package com.pawith.todoapplication.handler;
+
+import static org.mockito.BDDMockito.given;
+
+import com.pawith.commonmodule.UnitTestConfig;
+import com.pawith.commonmodule.event.TodoCompletionCheckEvent;
+import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import com.pawith.tododomain.entity.Assign;
+import com.pawith.tododomain.entity.CompletionStatus;
+import com.pawith.tododomain.entity.Todo;
+import com.pawith.tododomain.service.AssignQueryService;
+import com.pawith.tododomain.service.TodoQueryService;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@UnitTestConfig
+@DisplayName("TodoCompletionCheckOnTodoHandler 테스트")
+public class TodoCompletionCheckOnTodoHandlerTest {
+
+    @Mock
+    AssignQueryService assignQueryService;
+    @Mock
+    TodoQueryService todoQueryService;
+    private TodoCompletionCheckOnTodoHandler todoCompletionCheckOnTodoHandler;
+
+    @BeforeEach
+    void init(){
+        todoCompletionCheckOnTodoHandler = new TodoCompletionCheckOnTodoHandler(assignQueryService, todoQueryService);
+    }
+
+    @Test
+    @DisplayName("Todo 완료 여부 변경 테스트-담당자가 모두 완료하면 Todo 완료")
+    void changeTodoStatus() {
+        // given
+        final TodoCompletionCheckEvent todoCompletionCheckEvent = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
+                .giveMeOne(TodoCompletionCheckEvent.class);
+        final List<Assign> mockAssigns = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMeBuilder(Assign.class)
+                .set("completionStatus", CompletionStatus.COMPLETE)
+                .sampleList(3);
+        final Todo mockTodo = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMeBuilder(Todo.class)
+                .set("completionStatus", CompletionStatus.INCOMPLETE)
+                .sample();
+        given(assignQueryService.findAllAssignByTodoId(todoCompletionCheckEvent.getTodoId())).willReturn(mockAssigns);
+        given(todoQueryService.findTodoByTodoId(todoCompletionCheckEvent.getTodoId())).willReturn(mockTodo);
+        // when
+        todoCompletionCheckOnTodoHandler.changeTodoStatus(todoCompletionCheckEvent);
+        // then
+        Assertions.assertEquals(CompletionStatus.COMPLETE, mockTodo.getCompletionStatus());
+    }
+
+    @Test
+    @DisplayName("Todo 완료 여부 변경 테스트-담당자가 하나라도 미완료면 Todo 미완료")
+    void changeTodoStatusWithIncompletedAssignee() {
+        // given
+        final TodoCompletionCheckEvent todoCompletionCheckEvent = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
+                .giveMeOne(TodoCompletionCheckEvent.class);
+        final List<Assign> mockAssigns = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMeBuilder(Assign.class)
+                .set("completionStatus", CompletionStatus.COMPLETE)
+                .sampleList(2);
+        final Assign mockAssign = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMeBuilder(Assign.class)
+                .set("completionStatus", CompletionStatus.INCOMPLETE)
+                .sample();
+        mockAssigns.add(mockAssign);
+        final Todo mockTodo = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMeBuilder(Todo.class)
+                .set("completionStatus", CompletionStatus.INCOMPLETE)
+                .sample();
+        given(assignQueryService.findAllAssignByTodoId(todoCompletionCheckEvent.getTodoId())).willReturn(mockAssigns);
+        given(todoQueryService.findTodoByTodoId(todoCompletionCheckEvent.getTodoId())).willReturn(mockTodo);
+        // when
+        todoCompletionCheckOnTodoHandler.changeTodoStatus(todoCompletionCheckEvent);
+        // then
+        Assertions.assertEquals(CompletionStatus.INCOMPLETE, mockTodo.getCompletionStatus());
+    }
+
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/handler/TodoCompletionCheckOnTodoHandlerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/handler/TodoCompletionCheckOnTodoHandlerTest.java
@@ -3,7 +3,7 @@ package com.pawith.todoapplication.handler;
 import static org.mockito.BDDMockito.given;
 
 import com.pawith.commonmodule.UnitTestConfig;
-import com.pawith.commonmodule.event.TodoCompletionCheckEvent;
+import com.pawith.todoapplication.handler.event.TodoCompletionCheckEvent;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
 import com.pawith.tododomain.entity.Assign;
 import com.pawith.tododomain.entity.CompletionStatus;

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/AssignChageUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/AssignChageUseCaseTest.java
@@ -1,0 +1,65 @@
+package com.pawith.todoapplication.service;
+
+import static org.mockito.BDDMockito.given;
+
+import com.pawith.commonmodule.UnitTestConfig;
+import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import com.pawith.tododomain.entity.Assign;
+import com.pawith.tododomain.entity.CompletionStatus;
+import com.pawith.tododomain.entity.Todo;
+import com.pawith.tododomain.service.AssignQueryService;
+import com.pawith.tododomain.service.TodoQueryService;
+import com.pawith.userdomain.entity.User;
+import com.pawith.userdomain.utils.UserUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.context.ApplicationEventPublisher;
+
+@UnitTestConfig
+@DisplayName("AssignChageUseCase 테스트")
+public class AssignChageUseCaseTest {
+
+    @Mock
+    AssignQueryService assignQueryService;
+    @Mock
+    TodoQueryService todoQueryService;
+    @Mock
+    private UserUtils userUtils;
+    @Mock
+    ApplicationEventPublisher applicationEventPublisher;
+
+    private AssignChangeUseCase assignChangeUseCase;
+
+    @BeforeEach
+    void init(){
+        assignChangeUseCase = new AssignChangeUseCase(assignQueryService, todoQueryService, userUtils, applicationEventPublisher);
+    }
+
+    @Test
+    @DisplayName("담당자 Todo 완료 여부 변경 테스트")
+    void changeAssignStatus() {
+        // given
+        final User mockUser = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMeOne(User.class);
+        final Todo mockTodo = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMeOne(Todo.class);
+        final Assign mockAssign = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeBuilder(Assign.class)
+                .set("userId", mockUser.getId())
+                .set("todoId", mockTodo.getId())
+                .set("completionStatus", CompletionStatus.INCOMPLETE)
+                .sample();
+        final Long todoId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey()
+                .giveMeOne(Long.class);
+        given(userUtils.getAccessUser()).willReturn(mockUser);
+        given(todoQueryService.findTodoByTodoId(todoId)).willReturn(mockTodo);
+        given(assignQueryService.findAssignByTodoIdAndUserId(mockTodo.getId(), mockUser.getId())).willReturn(mockAssign);
+        // when
+        assignChangeUseCase.changeAssignStatus(todoId);
+        // then
+        Assertions.assertEquals(CompletionStatus.COMPLETE, mockAssign.getCompletionStatus());
+    }
+
+}

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Assign.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Assign.java
@@ -23,6 +23,9 @@ public class Assign extends BaseEntity {
 
     private Boolean isDeleted = Boolean.FALSE;
 
+    @Enumerated(EnumType.STRING)
+    private CompletionStatus completionStatus;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "todo_id")
     private Todo todo;
@@ -35,5 +38,12 @@ public class Assign extends BaseEntity {
     public Assign(Todo todo, Register register) {
         this.todo = todo;
         this.register = register;
+    }
+
+    public void updateCompletionStatus() {
+        if(this.completionStatus.equals(CompletionStatus.COMPLETE))
+            this.completionStatus = CompletionStatus.INCOMPLETE;
+        else
+            this.completionStatus = CompletionStatus.COMPLETE;
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/CompletionStatus.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/CompletionStatus.java
@@ -1,5 +1,5 @@
 package com.pawith.tododomain.entity;
 
-public enum TodoStatus {
+public enum CompletionStatus {
     COMPLETE, INCOMPLETE
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Todo.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Todo.java
@@ -1,14 +1,22 @@
 package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
+import java.time.LocalDate;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
-import java.time.LocalDate;
-import java.util.Objects;
 
 @Entity
 @Getter
@@ -23,7 +31,7 @@ public class Todo extends BaseEntity {
     private LocalDate scheduledDate;
 
     @Enumerated(EnumType.STRING)
-    private TodoStatus todoStatus;
+    private CompletionStatus completionStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
@@ -33,7 +41,7 @@ public class Todo extends BaseEntity {
     public Todo(String description, LocalDate scheduledDate, Category category) {
         this.description = description;
         this.scheduledDate = scheduledDate;
-        this.todoStatus = TodoStatus.INCOMPLETE;
+        this.completionStatus = CompletionStatus.INCOMPLETE;
         this.category = category;
     }
 
@@ -47,5 +55,11 @@ public class Todo extends BaseEntity {
         if(this.description.equals(description))
             return;
         this.description = Objects.requireNonNull(description, "nickname must be not null");
+    }
+
+    public void updateCompletionStatus(CompletionStatus completionStatus){
+        if(this.completionStatus.equals(completionStatus))
+            return;
+        this.completionStatus = Objects.requireNonNull(completionStatus, "nickname must be not null");
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/AssignRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/AssignRepository.java
@@ -20,4 +20,17 @@ public interface AssignRepository extends JpaRepository<Assign, Long> {
     @Modifying
     @Query("update Assign a set a.isDeleted = true where a.register.id in (:registerIds)")
     void deleteByRegisterIds(final List<Long> registerIds);
+
+    @Query("select a " +
+            "from Assign a " +
+            "join fetch a.register " +
+            "join fetch a.todo t " +
+            "where t.id=:todoId and a.register.userId=:userId")
+    Assign findByTodoIdAndUserId(Long todoId, Long userId);
+
+    @Query("select a " +
+            "from Assign a " +
+            "join fetch a.todo t " +
+            "where t.id=:todoId")
+    List<Assign> findAllByTodoId(Long todoId);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
@@ -23,7 +23,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
         "from Todo t " +
         "join Register r on r.userId=:userId and r.todoTeam.id=:todoTeamId " +
         "join Assign  a on a.register.id=r.id " +
-        "where a.todo.id=t.id and t.scheduledDate = :scheduledDate and t.todoStatus='COMPLETE'"
+        "where a.todo.id=t.id and t.scheduledDate = :scheduledDate and t.completionStatus='COMPLETE'"
     )
     Long countCompleteTodoByDate(@Param("userId") Long userId, @Param("todoTeamId") Long todoTeamId, @Param("scheduledDate") LocalDate scheduledDate);
 
@@ -39,7 +39,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
             "from Todo t " +
             "join Register r on r.userId=:userId and r.todoTeam.id=:todoTeamId " +
             "join Assign  a on a.register.id=r.id " +
-            "where a.todo.id=t.id and t.scheduledDate between :startDate and :endDate and t.todoStatus='COMPLETE'"
+            "where a.todo.id=t.id and t.scheduledDate between :startDate and :endDate and t.completionStatus='COMPLETE'"
     )
     Long countCompleteTodoByBetweenDate(@Param("userId") Long userId, @Param("todoTeamId") Long todoTeamId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/AssignQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/AssignQueryService.java
@@ -20,4 +20,12 @@ public class AssignQueryService {
         return assignRepository.findAllByCategoryIdAndScheduledDate(categoryId, scheduledDate);
     }
 
+    public Assign findAssignByTodoIdAndUserId(Long todoId, Long userId) {
+        return assignRepository.findByTodoIdAndUserId(todoId, userId);
+    }
+
+    public List<Assign> findAllAssignByTodoId(Long todoId) {
+        return assignRepository.findAllByTodoId(todoId);
+    }
+
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
@@ -55,7 +55,7 @@ public class RegisterQueryService {
     }
 
     public List<Register> findAllRegistersByCategoryId(Long categoryId) {
-        return findRegisterList(registerRepository::findAllByCategoryId,categoryId);
+        return registerRepository.findAllByCategoryId(categoryId);
     }
 
     public List<Long> findUserIdsByCategoryId(Long categoryId){

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
@@ -54,6 +54,10 @@ public class RegisterQueryService {
         return findRegisterList(registerRepository::findByTodoId,todoId);
     }
 
+    public List<Register> findAllRegistersByCategoryId(Long categoryId) {
+        return findRegisterList(registerRepository::findAllByCategoryId,categoryId);
+    }
+
     public List<Long> findUserIdsByCategoryId(Long categoryId){
         return findRegisterList(registerRepository::findAllByCategoryId,categoryId).stream()
             .map(Register::getUserId)

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -74,7 +74,12 @@ operation::todo-controller-test/change-scheduled-date[snippets='http-request,pat
 
 operation::todo-controller-test/change-todo-name[snippets='http-request,path-parameters,request-headers,request-fields,http-response']
 
+[[담당자-Todo-완료]]
+=== 담당자 Todo 완료
 
+operation::todo-controller-test/put-assign-status[snippets='http-request,path-parameters,request-headers,http-response']
+
+[[Todo-완료]]
 [[Category-API]]
 == Category API
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -79,7 +79,11 @@ operation::todo-controller-test/change-todo-name[snippets='http-request,path-par
 
 operation::todo-controller-test/put-assign-status[snippets='http-request,path-parameters,request-headers,http-response']
 
-[[Todo-완료]]
+[[Todo-완료-여부-조회]]
+=== Todo 완료 여부 조회
+
+operation::todo-controller-test/get-todo-completion[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
 [[Category-API]]
 == Category API
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
@@ -66,4 +66,9 @@ public class TodoController {
         assignChangeUseCase.changeAssignStatus(todoId);
     }
 
+    @GetMapping("/todos/{todoId}/completion")
+    public TodoCompletionResponse getTodoCompletion(@PathVariable Long todoId){
+        return todoGetUseCase.getTodoCompletion(todoId);
+    }
+
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
@@ -23,6 +23,7 @@ public class TodoController {
     private final TodoRateGetUseCase todoRateGetUseCase;
     private final TodoCreateUseCase todoCreateUseCase;
     private final TodoChangeUseCase todoChangeUseCase;
+    private final AssignChangeUseCase assignChangeUseCase;
 
     @GetMapping("/{todoTeamId}/todos/progress")
     public TodoProgressResponse getTodoProgress(@PathVariable Long todoTeamId) {
@@ -58,6 +59,11 @@ public class TodoController {
     @PutMapping("/todos/{todoId}/description")
     public void putTodoDescription(@PathVariable Long todoId, @RequestBody TodoDescriptionChangeRequest todoDescriptionChangeRequest){
         todoChangeUseCase.changeTodoName(todoId, todoDescriptionChangeRequest);
+    }
+
+    @PutMapping("/todos/{todoId}/assign/complete")
+    public void putAssignStatus(@PathVariable Long todoId){
+        assignChangeUseCase.changeAssignStatus(todoId);
     }
 
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -44,6 +44,8 @@ public class TodoControllerTest extends BaseRestDocsTest {
     private TodoCreateUseCase todoCreateUseCase;
     @MockBean
     private TodoChangeUseCase todoChangeUseCase;
+    @MockBean
+    private AssignChangeUseCase assignChangeUseCase;
 
     private static final String TODO_REQUEST_URL = "/teams";
 
@@ -266,4 +268,24 @@ public class TodoControllerTest extends BaseRestDocsTest {
                 ));
     }
 
+    @Test
+    @DisplayName("담당자 투두 완료 API 테스트")
+    void putAssignStatus() throws Exception {
+        //given
+        final Long testTodoId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        MockHttpServletRequestBuilder request = put(TODO_REQUEST_URL + "/todos/{todoId}/assign/complete", testTodoId)
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("todoId").description("투두 항목 Id")
+                        )
+                ));
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -288,4 +288,30 @@ public class TodoControllerTest extends BaseRestDocsTest {
                         )
                 ));
     }
+
+    @Test
+    @DisplayName("투두 완료 여부 조회 API 테스트")
+    void getTodoCompletion() throws Exception {
+        //given
+        final Long testTodoId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        final TodoCompletionResponse todoCompletionResponse = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(TodoCompletionResponse.class);
+        given(todoGetUseCase.getTodoCompletion(testTodoId)).willReturn(todoCompletionResponse);
+        MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/todos/{todoId}/completion", testTodoId)
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("todoId").description("투두 항목 Id")
+                        ),
+                        responseFields(
+                                fieldWithPath("completionStatus").description("투두 완료 여부")
+                        )
+                ));
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -181,9 +181,10 @@ public class TodoControllerTest extends BaseRestDocsTest {
                         responseFields(
                                 fieldWithPath("todos[].todoId").description("투두 항목 Id"),
                                 fieldWithPath("todos[].task").description("투두 항목 이름"),
-                                fieldWithPath("todos[].status").description("투두 항목 상태(완료, 미완료)"),
+                                fieldWithPath("todos[].completionStatus").description("투두 항목 상태(완료, 미완료)"),
                                 fieldWithPath("todos[].assignNames[].assigneeId").description("할당받은 사용자의 ID"),
-                                fieldWithPath("todos[].assignNames[].assigneeName").description("할당받은 사용자의 이름")
+                                fieldWithPath("todos[].assignNames[].assigneeName").description("할당받은 사용자의 이름"),
+                                fieldWithPath("todos[].assignNames[].completionStatus").description("할당받은 사용자의 완료 상태(완료, 미완료)")
                         )
                 ));
     }


### PR DESCRIPTION
## 작업사항
- 담당자 Todo 완료 여부 변경 API 추가, 테스트 코드 작성 및 명세 반영
- Todo 최종 완료 여부 변경 이벤트로 구현
- Todo 최종 완료 여부 조회 API 추가, 테스트 코드 작성 및 명세 반영
- 담당자 Todo 완료 여부 필드 추가로 인한 카테고리 하위 Todo 조회 수정, 테스트 코드 반영
- Todo 완료 여부 관련 테스트 코드 작성(AssignChageUseCaseTest, TodoCompletionCheckOnTodoHandler)

## 변경로직
- 담당자에 Todo 완료 여부 필드 추가로 인해 TodoStatus Enum 클래스를 CompletionStatus로 네이밍 변경
- 담당자 Todo 완료 여부 필드 추가로 인한 카테고리 하위 Todo 조회 수정

## 참고자료
- 내용을 적어주세요.



