### PR TITLE
Pet 168 feat : TodoTeam 가입한 사용자 검색 API 추가, 사용자 조회 API 수정 

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterManageInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterManageInfoResponse.java
@@ -1,5 +1,6 @@
 package com.pawith.todoapplication.dto.response;
 
+import com.pawith.tododomain.entity.Authority;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,7 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class RegisterManageInfoResponse {
     private final Long registerId;
-    private final String authority;
+    private final Authority authority;
     private final String registerName;
     private final String registerEmail;
     private final String profileImage;

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterSearchInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterSearchInfoResponse.java
@@ -1,0 +1,20 @@
+package com.pawith.todoapplication.dto.response;
+
+import com.pawith.tododomain.entity.Authority;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RegisterSearchInfoResponse {
+    private Long registerId;
+    private Authority authority;
+    private String registerName;
+    private String registerEmail;
+    private String profileImage;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
@@ -3,11 +3,14 @@ package com.pawith.todoapplication.service;
 import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.todoapplication.dto.response.*;
+import com.pawith.tododomain.entity.Authority;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.service.RegisterQueryService;
 import com.pawith.userdomain.entity.User;
 import com.pawith.userdomain.service.UserQueryService;
 import com.pawith.userdomain.utils.UserUtils;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,10 +42,12 @@ public class RegistersGetUseCase {
     public ListResponse<RegisterManageInfoResponse> getManageRegisters(final Long teamId) {
         final List<Register> allRegisters = registerQueryService.findAllRegistersByTodoTeamId(teamId);
         final Map<Long, User> registerUserMap = getRegisterUserMap(allRegisters);
+        Comparator<Authority> authorityComparator = Comparator.comparing(Enum::ordinal);
         final List<RegisterManageInfoResponse> manageRegisterInfoResponses = allRegisters.stream()
+                .sorted(Comparator.comparing(register -> register.getAuthority(), authorityComparator))
                 .map(register -> {
                     final User registerUser = registerUserMap.get(register.getUserId());
-                    return new RegisterManageInfoResponse(register.getId(), register.getAuthority().toString(), registerUser.getNickname(), registerUser.getEmail(), registerUser.getImageUrl());
+                    return new RegisterManageInfoResponse(register.getId(), register.getAuthority(), registerUser.getNickname(), registerUser.getEmail(), registerUser.getImageUrl());
                 })
                 .collect(Collectors.toList());
         return ListResponse.from(manageRegisterInfoResponses);

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/RegistersGetUseCase.java
@@ -61,4 +61,37 @@ public class RegistersGetUseCase {
             .collect(Collectors.toList());
         return userQueryService.findUserMapByIds(registerUserIds);
     }
+
+    public ListResponse<RegisterSearchInfoResponse> searchRegisterByNickname(final Long todoTeamId, final String nickname) {
+        final List<Register> registers = registerQueryService.findAllRegistersByTodoTeamId(todoTeamId);
+        final List<Long> registerUserIds = registers.stream()
+            .map(Register::getUserId)
+            .collect(Collectors.toList());
+        final List<User> users = userQueryService.findAllByNicknameAndIds(nickname, registerUserIds);
+        System.out.println(users);
+        final Map<User, Register> userRegisterMap = getRegisterUserMap(registers, users);
+        final List<RegisterSearchInfoResponse> registerSearchInfoResponses = users.stream()
+                .map(user -> {
+                    Register register = userRegisterMap.get(user);
+                    return new RegisterSearchInfoResponse(register.getId(), register.getAuthority(), user.getNickname(), user.getEmail(), user.getImageUrl());
+                })
+                .collect(Collectors.toList());
+        return ListResponse.from(registerSearchInfoResponses);
+    }
+
+    private Map<User, Register> getRegisterUserMap(List<Register> registers, List<User> users) {
+        Comparator<Authority> authorityComparator = Comparator.comparing(Enum::ordinal);
+
+        List<Register> sortedRegisters = registers.stream()
+                .sorted(Comparator.comparing(Register::getAuthority, authorityComparator))
+                .collect(Collectors.toList());
+
+        Map<User, Register> userRegisterMap = users.stream()
+                .flatMap(user -> sortedRegisters.stream()
+                        .filter(register -> user.getId().equals(register.getUserId()))
+                        .map(register -> Map.entry(user, register)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (existing, replacement) -> existing, LinkedHashMap::new));
+
+        return userRegisterMap;
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -137,6 +137,11 @@ operation::register-controller-test/get-manage-registers[snippets='http-request,
 
 operation::register-controller-test/put-authority[snippets='http-request,path-parameters,request-headers,request-fields,http-response']
 
+[[Todo-Teamd에-가입된-사용자-검색]]
+=== Todo Team에 가입된 사용자 검색
+
+operation::register-controller-test/get-register-by-nickname[snippets='http-request,path-parameters,request-headers,request-parameters,http-response,response-fields']
+
 [[Todo-Team-탈퇴]]
 === Todo Team 탈퇴
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
@@ -4,6 +4,7 @@ import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.todoapplication.dto.request.AuthorityChangeRequest;
 import com.pawith.todoapplication.dto.response.RegisterInfoResponse;
 import com.pawith.todoapplication.dto.response.RegisterManageInfoResponse;
+import com.pawith.todoapplication.dto.response.RegisterSearchInfoResponse;
 import com.pawith.todoapplication.dto.response.RegisterTermResponse;
 import com.pawith.todoapplication.service.ChangeRegisterUseCase;
 import com.pawith.todoapplication.service.RegistersGetUseCase;
@@ -50,6 +51,11 @@ public class RegisterController {
     @PutMapping("/{todoTeamId}/registers/{registerId}")
     public void putAuthority(@PathVariable Long todoTeamId, @PathVariable Long registerId, @RequestBody AuthorityChangeRequest authorityChangeRequest) {
         changeRegisterUseCase.changeAuthority(todoTeamId, registerId, authorityChangeRequest);
+    }
+
+    @GetMapping("/{todoTeamId}/registers/search")
+    public ListResponse<RegisterSearchInfoResponse> getRegisterByNickname(@PathVariable Long todoTeamId, @RequestParam("nickname") String nickname) {
+        return registersGetUseCase.searchRegisterByNickname(todoTeamId, nickname);
     }
 
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -204,4 +204,39 @@ class RegisterControllerTest extends BaseRestDocsTest {
                 )
             ));
     }
+
+    @Test
+    @DisplayName("닉네임으로 Register를 검색하는 테스트")
+    void getRegisterByNickname() throws Exception {
+        //given
+        final Long todoTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
+        final String nickname = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(String.class);
+        final List<RegisterSearchInfoResponse> registerSearchInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(RegisterSearchInfoResponse.class, 2);
+        given(registersGetUseCase.searchRegisterByNickname(todoTeamId, nickname)).willReturn(ListResponse.from(registerSearchInfoResponses));
+        MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}/registers/search", todoTeamId)
+            .queryParam("nickname", nickname)
+            .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+            .andDo(resultHandler.document(
+                requestHeaders(
+                    headerWithName("Authorization").description("access 토큰")
+                ),
+                pathParameters(
+                    parameterWithName("todoTeamId").description("TodoTeam의 Id")
+                ),
+                requestParameters(
+                    parameterWithName("nickname").description("검색할 Register의 nickname")
+                ),
+                responseFields(
+                    fieldWithPath("content[].registerId").description("Register의 Id"),
+                    fieldWithPath("content[].authority").description("Register의 권한"),
+                    fieldWithPath("content[].registerName").description("Register의 이름"),
+                    fieldWithPath("content[].registerEmail").description("Register의 이메일"),
+                    fieldWithPath("content[].profileImage").description("Register의 프로필 이미지")
+                )
+            ));
+    }
 }

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/repository/UserRepository.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/repository/UserRepository.java
@@ -13,4 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("select u from User u where u.id in :ids")
     List<User> findAllByIds(List<Long> ids);
+
+    @Query("select u from User u where u.nickname = :nickname and u.id in :ids")
+    List<User> findAllByNicknameAndIds(String nickname, List<Long> ids);
+
 }

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/service/UserQueryService.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/service/UserQueryService.java
@@ -50,4 +50,8 @@ public class UserQueryService {
     public boolean checkEmailAlreadyExist(String email) {
         return userRepository.existsByEmail(email);
     }
+
+    public List<User> findAllByNicknameAndIds(String nickname, List<Long> userIds) {
+        return userRepository.findAllByNicknameAndIds(nickname, userIds);
+    }
 }


### PR DESCRIPTION
## 작업사항
- TodoTeam 가입한 사용자 검색 API 추가
- 사용자 조회 응답필드 중 Authority enum으로 반환하도록 수정
- 사용자 조회 API  관리자, 운영진, 멤버 순서대로 정렬해서 반환하도록 수정 

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



