### PR TITLE
Pet 170 TodoTeam 탈퇴, 서비스 탈퇴 시 담당했던 Todo 조회 API

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterTermResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/RegisterTermResponse.java
@@ -1,26 +1,15 @@
 package com.pawith.todoapplication.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RegisterTermResponse {
-    private RegisterTerm registerTerm;
-
-    public enum RegisterTerm {
-        FIRST_WEEK,
-        SECOND_WEEK,
-        AFTER_SECOND_WEEK
-    }
-
-    public RegisterTermResponse(Integer registerTerm) {
-        if (registerTerm >= 0 && registerTerm <= 6) {
-            this.registerTerm = RegisterTerm.FIRST_WEEK;
-        } else if (registerTerm > 6 && registerTerm <= 13) {
-            this.registerTerm = RegisterTerm.SECOND_WEEK;
-        } else {
-            this.registerTerm = RegisterTerm.AFTER_SECOND_WEEK;
-        }
-    }
+    private Integer registerTerm;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoCountResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoCountResponse.java
@@ -1,0 +1,15 @@
+package com.pawith.todoapplication.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TodoCountResponse {
+    private int todoCount;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/WithdrawAllTodoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/WithdrawAllTodoResponse.java
@@ -1,0 +1,17 @@
+package com.pawith.todoapplication.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithdrawAllTodoResponse {
+    private String teamProfileImage;
+    private String categoryName;
+    private String task;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/WithdrawTodoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/WithdrawTodoResponse.java
@@ -1,0 +1,16 @@
+package com.pawith.todoapplication.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithdrawTodoResponse {
+    private String categoryName;
+    private String task;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/WithdrawTodoTeamResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/WithdrawTodoTeamResponse.java
@@ -1,0 +1,16 @@
+package com.pawith.todoapplication.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithdrawTodoTeamResponse {
+    private String teamProfileImage;
+    private String teamName;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/CategoryDeleteOnTodoHandler.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/CategoryDeleteOnTodoHandler.java
@@ -1,0 +1,25 @@
+package com.pawith.todoapplication.handler;
+
+import com.pawith.todoapplication.handler.event.CategoryDeleteEvent;
+import com.pawith.tododomain.service.AssignDeleteService;
+import com.pawith.tododomain.service.TodoDeleteService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class CategoryDeleteOnTodoHandler {
+    private final TodoDeleteService todoDeleteService;
+    private final AssignDeleteService assignDeleteService;
+
+    @EventListener
+    public void deleteAllByCategoryId(CategoryDeleteEvent categoryDeleteEvent) {
+        todoDeleteService.deleteTodoByCategoryId(categoryDeleteEvent.getCategoryId());
+        assignDeleteService.deleteAssignByCategoryId(categoryDeleteEvent.getCategoryId());
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/event/CategoryDeleteEvent.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/event/CategoryDeleteEvent.java
@@ -1,0 +1,10 @@
+package com.pawith.todoapplication.handler.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CategoryDeleteEvent {
+    private final Long categoryId;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/CategoryDeleteUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/CategoryDeleteUseCase.java
@@ -1,8 +1,10 @@
 package com.pawith.todoapplication.service;
 
 import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.todoapplication.handler.event.CategoryDeleteEvent;
 import com.pawith.tododomain.service.CategoryDeleteService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
 @ApplicationService
@@ -11,8 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class CategoryDeleteUseCase {
 
     private final CategoryDeleteService categoryDeleteService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public void deleteCategory(Long categoryId) {
         categoryDeleteService.deleteCategory(categoryId);
+        applicationEventPublisher.publishEvent(new CategoryDeleteEvent(categoryId));
     }
 }
+

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -5,6 +5,7 @@ import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.commonmodule.response.SliceResponse;
 import com.pawith.todoapplication.dto.response.AssignUserInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoCompletionResponse;
+import com.pawith.todoapplication.dto.response.TodoCountResponse;
 import com.pawith.todoapplication.dto.response.TodoInfoResponse;
 import com.pawith.todoapplication.dto.response.CategorySubTodoResponse;
 import com.pawith.todoapplication.dto.response.WithdrawAllTodoResponse;
@@ -93,6 +94,18 @@ public class TodoGetUseCase {
                 todoQueryService.findAllTodoListByUserId(user.getId(), pageable)
                         .map(todo -> new WithdrawAllTodoResponse(todo.getCategory().getTodoTeam().getImageUrl(), todo.getCategory().getName(), todo.getDescription()));
         return SliceResponse.from(withdrawAllTodoResponses);
+    }
+
+    public TodoCountResponse getWithdrawTeamTodoCount(Long todoTeamId) {
+        final User user = userUtils.getAccessUser();
+        final Integer todoCount = todoQueryService.countTodoByTodoTeamId(user.getId(), todoTeamId);
+        return new TodoCountResponse(todoCount);
+    }
+
+    public TodoCountResponse getWithdrawTodoCount() {
+        final User user = userUtils.getAccessUser();
+        final Integer todoCount = todoQueryService.countTodoByUserId(user.getId());
+        return new TodoCountResponse(todoCount);
     }
 
     private Map<Todo, List<Assign>> getTodoMap(Long categoryId, LocalDate moveDate) {

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -2,10 +2,12 @@ package com.pawith.todoapplication.service;
 
 import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.commonmodule.response.ListResponse;
+import com.pawith.commonmodule.response.SliceResponse;
 import com.pawith.todoapplication.dto.response.AssignUserInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoCompletionResponse;
 import com.pawith.todoapplication.dto.response.TodoInfoResponse;
 import com.pawith.todoapplication.dto.response.CategorySubTodoResponse;
+import com.pawith.todoapplication.dto.response.WithdrawTodoResponse;
 import com.pawith.tododomain.entity.Assign;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.entity.Todo;
@@ -23,6 +25,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
 @ApplicationService
@@ -72,6 +76,14 @@ public class TodoGetUseCase {
     public TodoCompletionResponse getTodoCompletion(Long todoId) {
         final Todo todo = todoQueryService.findTodoByTodoId(todoId);
         return new TodoCompletionResponse(todo.getCompletionStatus());
+    }
+
+    public SliceResponse<WithdrawTodoResponse> getWithdrawTeamTodoList(Long todoTeamId, final Pageable pageable) {
+        final User user = userUtils.getAccessUser();
+        final Slice<WithdrawTodoResponse> withdrawTodoResponses =
+                todoQueryService.findAllTodoListByTodoTeamId(user.getId(), todoTeamId, pageable)
+                        .map(todo -> new WithdrawTodoResponse(todo.getCategory().getName(), todo.getDescription()));
+        return SliceResponse.from(withdrawTodoResponses);
     }
 
     private Map<Todo, List<Assign>> getTodoMap(Long categoryId, LocalDate moveDate) {

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -7,6 +7,7 @@ import com.pawith.todoapplication.dto.response.AssignUserInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoCompletionResponse;
 import com.pawith.todoapplication.dto.response.TodoInfoResponse;
 import com.pawith.todoapplication.dto.response.CategorySubTodoResponse;
+import com.pawith.todoapplication.dto.response.WithdrawAllTodoResponse;
 import com.pawith.todoapplication.dto.response.WithdrawTodoResponse;
 import com.pawith.tododomain.entity.Assign;
 import com.pawith.tododomain.entity.Register;
@@ -84,6 +85,14 @@ public class TodoGetUseCase {
                 todoQueryService.findAllTodoListByTodoTeamId(user.getId(), todoTeamId, pageable)
                         .map(todo -> new WithdrawTodoResponse(todo.getCategory().getName(), todo.getDescription()));
         return SliceResponse.from(withdrawTodoResponses);
+    }
+
+    public SliceResponse<WithdrawAllTodoResponse> getWithdrawTodoList(Pageable pageable) {
+        final User user = userUtils.getAccessUser();
+        final Slice<WithdrawAllTodoResponse> withdrawAllTodoResponses =
+                todoQueryService.findAllTodoListByUserId(user.getId(), pageable)
+                        .map(todo -> new WithdrawAllTodoResponse(todo.getCategory().getTodoTeam().getImageUrl(), todo.getCategory().getName(), todo.getDescription()));
+        return SliceResponse.from(withdrawAllTodoResponses);
     }
 
     private Map<Todo, List<Assign>> getTodoMap(Long categoryId, LocalDate moveDate) {

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
@@ -7,6 +7,7 @@ import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
+import com.pawith.todoapplication.dto.response.WithdrawTodoTeamResponse;
 import com.pawith.todoapplication.mapper.TodoTeamMapper;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.entity.TodoTeam;
@@ -63,5 +64,15 @@ public class TodoTeamGetUseCase {
     public TodoTeamRandomCodeResponse getTodoTeamCode(Long teamId) {
         TodoTeam todoTeam = todoTeamQueryService.findTodoTeamById(teamId);
         return TodoTeamMapper.mapToTodoTeamRandomCodeResponse(todoTeam);
+    }
+
+    public ListResponse<WithdrawTodoTeamResponse> getWithdrawTodoTeam() {
+        User requestUser = userUtils.getAccessUser();
+        List<TodoTeam> todoTeamList = todoTeamQueryService.findAllTodoTeamByUserId(requestUser.getId());
+        return ListResponse.from(
+                todoTeamList.stream()
+                        .map(todoTeam -> new WithdrawTodoTeamResponse(todoTeam.getImageUrl(), todoTeam.getTeamName()))
+                        .collect(Collectors.toList())
+        );
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/AssignRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/AssignRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.repository.query.Param;
 
 public interface AssignRepository extends JpaRepository<Assign, Long> {
 
@@ -46,4 +47,8 @@ public interface AssignRepository extends JpaRepository<Assign, Long> {
             "join fetch a.todo t " +
             "where t.id=:todoId")
     List<Assign> findAllByTodoId(Long todoId);
+
+    @Modifying
+    @Query("update Assign a set a.isDeleted = true where a.todo.id in (select t.id from Todo t where t.category.id = :categoryId)")
+    void deleteAllByCategoryId(@Param("categoryId") Long categoryId);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
@@ -56,14 +56,17 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     void deleteById(Long todoId);
 
     @Query("select t from Todo t " +
+            "join fetch t.category " +
             "join Register r on r.userId=:userId and r.todoTeam.id=:todoTeamId " +
             "join Assign  a on a.register.id=r.id " +
             "where a.todo.id=t.id")
     Slice<Todo> findTodoSliceByUserIdAndTodoTeamId(Long userId, Long todoTeamId, Pageable pageable);
 
     @Query("select t from Todo t " +
+            "join fetch t.category c " +
+            "join fetch c.todoTeam " +
             "join Register r on r.userId=:userId " +
-            "join Assign  a on a.register.id=r.id " +
+            "join Assign a on a.register.id=r.id " +
             "where a.todo.id=t.id")
     Slice<Todo> findTodoSliceByUserId(Long userId, Pageable pageable);
 

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
@@ -66,4 +66,16 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
             "join Assign  a on a.register.id=r.id " +
             "where a.todo.id=t.id")
     Slice<Todo> findTodoSliceByUserId(Long userId, Pageable pageable);
+
+    @Query("select count(t) from Todo t " +
+            "join Register r on r.userId=:userId and r.todoTeam.id=:todoTeamId " +
+            "join Assign  a on a.register.id=r.id " +
+            "where a.todo.id=t.id")
+    Integer countTodoByUserIdAndTodoTeamId(Long userId, Long todoTeamId);
+
+    @Query("select count(t) from Todo t " +
+            "join Register r on r.userId=:userId " +
+            "join Assign  a on a.register.id=r.id " +
+            "where a.todo.id=t.id")
+    Integer countTodoByUserId(Long userId);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
@@ -4,6 +4,7 @@ import com.pawith.tododomain.entity.Todo;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -47,6 +48,10 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
             "join Category c on c.id=:categoryId " +
             "where t.category.id = c.id and t.scheduledDate = :moveDate")
     List<Todo> findTodoListByCategoryIdAndscheduledDate(Long categoryId, LocalDate moveDate);
+
+    @Modifying
+    @Query("update Todo t set t.isDeleted = true where t.category.id=:categoryId")
+    void deleteAllByCategoryId(@Param("categoryId") Long categoryId);
 
     void deleteById(Long todoId);
 

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
@@ -60,4 +60,10 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
             "join Assign  a on a.register.id=r.id " +
             "where a.todo.id=t.id")
     Slice<Todo> findTodoSliceByUserIdAndTodoTeamId(Long userId, Long todoTeamId, Pageable pageable);
+
+    @Query("select t from Todo t " +
+            "join Register r on r.userId=:userId " +
+            "join Assign  a on a.register.id=r.id " +
+            "where a.todo.id=t.id")
+    Slice<Todo> findTodoSliceByUserId(Long userId, Pageable pageable);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
@@ -49,4 +49,10 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     List<Todo> findTodoListByCategoryIdAndscheduledDate(Long categoryId, LocalDate moveDate);
 
     void deleteById(Long todoId);
+
+    @Query("select t from Todo t " +
+            "join Register r on r.userId=:userId and r.todoTeam.id=:todoTeamId " +
+            "join Assign  a on a.register.id=r.id " +
+            "where a.todo.id=t.id")
+    Slice<Todo> findTodoSliceByUserIdAndTodoTeamId(Long userId, Long todoTeamId, Pageable pageable);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoTeamRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoTeamRepository.java
@@ -13,6 +13,6 @@ public interface TodoTeamRepository extends JpaRepository<TodoTeam, Long> {
 
     Boolean existsByTeamCode(String teamCode);
 
-    @Query("select t from TodoTeam t join Register r on r.userId = :userId where r.todoTeam.id = t.id")
+    @Query("select t from TodoTeam t join Register r on r.userId = :userId where r.todoTeam.id = t.id and r.isRegistered = true")
     List<TodoTeam> findAllByUserId(@Param("userId") Long userId);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/AssignDeleteService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/AssignDeleteService.java
@@ -20,4 +20,8 @@ public class AssignDeleteService {
     public void deleteAllByTodoId(final Long todoId){
         assignRepository.deleteAllByTodoId(todoId);
     }
+
+    public void deleteAssignByCategoryId(final Long categoryId){
+        assignRepository.deleteAllByCategoryId(categoryId);
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/TodoDeleteService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/TodoDeleteService.java
@@ -16,4 +16,7 @@ public class TodoDeleteService {
         todoRepository.deleteById(todoId);
     }
 
+    public void deleteTodoByCategoryId(Long categoryId) {
+        todoRepository.deleteAllByCategoryId(categoryId);
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/TodoQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/TodoQueryService.java
@@ -54,4 +54,8 @@ public class TodoQueryService {
         final Long countCompleteWeekTodo = todoRepository.countCompleteTodoByBetweenDate(userId, todoTeamId, now, firstDayOfWeek);
         return (int) ((countCompleteWeekTodo / (double) countWeekTodo) * 100);
     }
+
+    public Slice<Todo> findAllTodoListByTodoTeamId(Long userId, Long todoTeamId, Pageable pageable) {
+        return todoRepository.findTodoSliceByUserIdAndTodoTeamId(userId, todoTeamId, pageable);
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/TodoQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/TodoQueryService.java
@@ -62,4 +62,12 @@ public class TodoQueryService {
     public Slice<Todo> findAllTodoListByUserId(Long userId, Pageable pageable) {
         return todoRepository.findTodoSliceByUserId(userId, pageable);
     }
+
+    public Integer countTodoByTodoTeamId(Long userId, Long todoTeamId) {
+        return todoRepository.countTodoByUserIdAndTodoTeamId(userId, todoTeamId);
+    }
+
+    public Integer countTodoByUserId(Long userId) {
+        return todoRepository.countTodoByUserId(userId);
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/TodoQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/TodoQueryService.java
@@ -58,4 +58,8 @@ public class TodoQueryService {
     public Slice<Todo> findAllTodoListByTodoTeamId(Long userId, Long todoTeamId, Pageable pageable) {
         return todoRepository.findTodoSliceByUserIdAndTodoTeamId(userId, todoTeamId, pageable);
     }
+
+    public Slice<Todo> findAllTodoListByUserId(Long userId, Pageable pageable) {
+        return todoRepository.findTodoSliceByUserId(userId, pageable);
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -100,6 +100,11 @@ operation::todo-controller-test/post-notification[snippets='http-request,request
 === TodoTeam 탈퇴시 담당했던 Todo 조회
 
 operation::todo-controller-test/get-withdraw-todo-list[snippets='http-request,path-parameters,request-headers,request-parameters,http-response,response-fields']
+
+[[서비스-탈퇴시-담당했던-Todo-조회]]
+=== 서비스 탈퇴시 담당했던 Todo 조회
+
+operation::todo-controller-test/get-all-withdraw-todo-list[snippets='http-request,request-headers,request-parameters,http-response,response-fields']
 [[Category-API]]
 == Category API
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -36,6 +36,11 @@ operation::todo-team-controller-test/get-todo-team-code[snippets='http-request,p
 
 operation::todo-team-controller-test/get-todo-team-by-code[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 
+[[서비스-탈퇴시-가입된-Todo-Team-조회]]
+=== 서비스 탈퇴시 가입된 Todo Team 조회
+
+operation::todo-team-controller-test/get-withdraw-todo-team[snippets='http-request,request-headers,http-response,response-fields']
+
 [[Todo-API]]
 == Todo API
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -96,6 +96,10 @@ operation::todo-controller-test/post-notification[snippets='http-request,request
 
 [[Todo-알림-설정-조회]]
 
+[[TodoTeam-탈퇴시-담당했던-Todo-조회]]
+=== TodoTeam 탈퇴시 담당했던 Todo 조회
+
+operation::todo-controller-test/get-withdraw-todo-list[snippets='http-request,path-parameters,request-headers,request-parameters,http-response,response-fields']
 [[Category-API]]
 == Category API
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -110,6 +110,16 @@ operation::todo-controller-test/get-withdraw-todo-list[snippets='http-request,pa
 === 서비스 탈퇴시 담당했던 Todo 조회
 
 operation::todo-controller-test/get-all-withdraw-todo-list[snippets='http-request,request-headers,request-parameters,http-response,response-fields']
+
+[[TodoTeam-탈퇴시-담당했던-Todo-개수-조회]]
+=== TodoTeam 탈퇴시 담당했던 Todo 개수 조회
+
+operation::todo-controller-test/get-withdraw-todo-count[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
+[[서비스-탈퇴시-담당했던-Todo-개수-조회]]
+=== 서비스 탈퇴시 담당했던 Todo 개수 조회
+
+operation::todo-controller-test/get-all-withdraw-todo-count[snippets='http-request,request-headers,http-response,response-fields']
 [[Category-API]]
 == Category API
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
@@ -1,6 +1,7 @@
 package com.pawith.todopresentation;
 
 import com.pawith.commonmodule.response.ListResponse;
+import com.pawith.commonmodule.response.SliceResponse;
 import com.pawith.todoapplication.dto.request.ScheduledDateChangeRequest;
 import com.pawith.todoapplication.dto.request.TodoCreateRequest;
 import com.pawith.todoapplication.dto.request.TodoDescriptionChangeRequest;
@@ -8,6 +9,7 @@ import com.pawith.todoapplication.dto.response.*;
 import com.pawith.todoapplication.service.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
@@ -81,6 +83,11 @@ public class TodoController {
     @PostMapping("/todos/{todoId}/assign/notification")
     public void postTodoAssignAlarm(@PathVariable Long todoId, @RequestParam("notificationTime") @DateTimeFormat(iso = DateTimeFormat.ISO.TIME) LocalTime notificationTime){
         todoNotificationCreateUseCase.createNotification(todoId, notificationTime);
+    }
+
+    @GetMapping("/{todoTeamId}/todos/withdraw")
+    public SliceResponse<WithdrawTodoResponse> getWithdrawTeamTodoList(@PathVariable Long todoTeamId, Pageable pageable){
+        return todoGetUseCase.getWithdrawTeamTodoList(todoTeamId, pageable);
     }
 
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
@@ -90,4 +90,9 @@ public class TodoController {
         return todoGetUseCase.getWithdrawTeamTodoList(todoTeamId, pageable);
     }
 
+    @GetMapping("/todos/withdraw")
+    public SliceResponse<WithdrawAllTodoResponse> getWithdrawTodoList(Pageable pageable){
+        return todoGetUseCase.getWithdrawTodoList(pageable);
+    }
+
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
@@ -95,4 +95,15 @@ public class TodoController {
         return todoGetUseCase.getWithdrawTodoList(pageable);
     }
 
+    @GetMapping("/{todoTeamId}/todos/withdraw/count")
+    public TodoCountResponse getTodoCount(@PathVariable Long todoTeamId){
+        return todoGetUseCase.getWithdrawTeamTodoCount(todoTeamId);
+    }
+
+    @GetMapping("/todos/withdraw/count")
+    public TodoCountResponse getTodoCount(){
+        return todoGetUseCase.getWithdrawTodoCount();
+    }
+
+
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
@@ -7,6 +7,7 @@ import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
+import com.pawith.todoapplication.dto.response.WithdrawTodoTeamResponse;
 import com.pawith.todoapplication.service.TodoTeamCreateUseCase;
 import com.pawith.todoapplication.service.TodoTeamGetUseCase;
 import com.pawith.todoapplication.service.TodoTeamRandomCodeGetUseCase;
@@ -60,5 +61,10 @@ public class TodoTeamController {
     @GetMapping("/{todoTeamId}/codes")
     public TodoTeamRandomCodeResponse getTodoTeamCode(@PathVariable Long todoTeamId){
         return todoTeamGetUseCase.getTodoTeamCode(todoTeamId);
+    }
+
+    @GetMapping("/withdraw")
+    public ListResponse<WithdrawTodoTeamResponse> getWithdrawTodoTeamList() {
+        return todoTeamGetUseCase.getWithdrawTodoTeam();
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -200,7 +200,7 @@ class RegisterControllerTest extends BaseRestDocsTest {
                     parameterWithName("todoTeamId").description("TodoTeam의 Id")
                 ),
                 responseFields(
-                    fieldWithPath("registerTerm").description("팀 가입 한 기간. FIRST_WEEK : 1주, SECOND_WEEK : 2주, AFTER_SECOND_WEEK : 2주 이상")
+                    fieldWithPath("registerTerm").description("팀 가입한 기간")
                 )
             ));
     }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -407,4 +407,42 @@ public class TodoControllerTest extends BaseRestDocsTest {
                 ));
     }
 
+    @Test
+    @DisplayName("서비스 탈퇴 시 담당했던 투두들 조회 API 테스트")
+    void getAllWithdrawTodoList() throws Exception {
+        //given
+        final PageRequest pageRequest = PageRequest.of(0, 6);
+        final List<WithdrawAllTodoResponse> withdrawAllTodoResponses = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMeBuilder(WithdrawAllTodoResponse.class)
+                .sampleList(pageRequest.getPageSize());
+        final SliceImpl<WithdrawAllTodoResponse> slice = new SliceImpl(withdrawAllTodoResponses, pageRequest, true);
+
+        given(todoGetUseCase.getWithdrawTodoList(any())).willReturn(SliceResponse.from(slice));
+        MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/todos/withdraw")
+                .queryParam("page", String.valueOf(pageRequest.getPageNumber()))
+                .queryParam("size", String.valueOf(pageRequest.getPageSize()))
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        requestParameters(
+                                parameterWithName("page").description("요청 페이지"),
+                                parameterWithName("size").description("요청 사이즈")
+                        ),
+                        responseFields(
+                                fieldWithPath("content[].teamProfileImage").description("팀 프로필 이미지"),
+                                fieldWithPath("content[].categoryName").description("투두 항목 카테고리 이름"),
+                                fieldWithPath("content[].task").description("투두 항목 이름"),
+                                fieldWithPath("page").description("요청 페이지"),
+                                fieldWithPath("size").description("요청 사이즈"),
+                                fieldWithPath("hasNext").description("다음 데이터 존재 여부")
+                        )
+                ));
+    }
+
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -445,4 +445,52 @@ public class TodoControllerTest extends BaseRestDocsTest {
                 ));
     }
 
+    @Test
+    @DisplayName("투두 팀 탈퇴시 담당했던 Todo 개수 조회 API 테스트")
+    void getWithdrawTodoCount() throws Exception {
+        //given
+        final Long testTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        final TodoCountResponse todoCountResponse = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(TodoCountResponse.class);
+        given(todoGetUseCase.getWithdrawTeamTodoCount(any())).willReturn(todoCountResponse);
+        MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/{todoTeamId}/todos/withdraw/count", testTeamId)
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("todoTeamId").description("투두 팀 Id")
+                        ),
+                        responseFields(
+                                fieldWithPath("todoCount").description("투두 개수")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("서비스 탈퇴시 담당했던 Todo 개수 조회 API 테스트")
+    void getAllWithdrawTodoCount() throws Exception {
+        //given
+        final TodoCountResponse todoCountResponse = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(TodoCountResponse.class);
+        given(todoGetUseCase.getWithdrawTodoCount()).willReturn(todoCountResponse);
+        MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/todos/withdraw/count")
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("todoCount").description("투두 개수")
+                        )
+                ));
+    }
+
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -8,6 +8,7 @@ import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
+import com.pawith.todoapplication.dto.response.WithdrawTodoTeamResponse;
 import com.pawith.todoapplication.service.TodoTeamCreateUseCase;
 import com.pawith.todoapplication.service.TodoTeamGetUseCase;
 import com.pawith.todoapplication.service.TodoTeamRandomCodeGetUseCase;
@@ -247,5 +248,28 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
                     fieldWithPath("teamImageUrl").description("TodoTeam의 이미지")
                 )
             ));
+    }
+
+    @Test
+    @DisplayName("서비스 탈퇴 시 가입한 팀 조회 API 테스트")
+    void getWithdrawTodoTeam() throws Exception {
+        //given
+        final List<WithdrawTodoTeamResponse> withdrawTodoTeamResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(WithdrawTodoTeamResponse.class, 5);
+        given(todoTeamGetUseCase.getWithdrawTodoTeam()).willReturn(ListResponse.from(withdrawTodoTeamResponses));
+        MockHttpServletRequestBuilder request = get(TODO_TEAM_REQUEST_URL + "/withdraw")
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("content[].teamProfileImage").description("TodoTeam의 이미지"),
+                                fieldWithPath("content[].teamName").description("TodoTeam의 이름")
+                        )
+                ));
     }
 }


### PR DESCRIPTION
## 작업사항
- TodoTeam 탈퇴, 서비스 탈퇴 시 담당했던 Todo 조회 API 추가, 테스트 코드 작성 및 명세 반영
- TodoTeam 탈퇴, 서비스 탈퇴 시 담당했던 Todo 개수 조회 API 추가, 테스트 코드 작성 및 명세 반영

## 변경로직
- Category 삭제 시 관련된 Todo와 Assign 정보 삭제 하도록 변경
- TodoTeam 탈퇴 후, 메인 화면으로 돌아갔을 때 가입한 TodoTeam 리스트에서 해당 TodoTeam은 사라지게 수정

## 참고자료
- 내용을 적어주세요.



