### PR TITLE
Pet 172

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/request/PetInfoChangeRequest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/request/PetInfoChangeRequest.java
@@ -1,0 +1,17 @@
+package com.pawith.todoapplication.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PetInfoChangeRequest {
+    private String name;
+    private Integer age;
+    private String genus;
+    private String species;
+    private String description;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/request/TodoTeamInfoChangeRequest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/request/TodoTeamInfoChangeRequest.java
@@ -1,0 +1,11 @@
+package com.pawith.todoapplication.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TodoTeamInfoChangeRequest {
+    private String teamName;
+    private String description;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/PetInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/PetInfoResponse.java
@@ -1,0 +1,19 @@
+package com.pawith.todoapplication.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PetInfoResponse {
+    private Long petId;
+    private String imageUrl;
+    private String petName;
+    private Integer petAge;
+    private String petGenus;
+    private String petSpecies;
+    private String petDescription;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamInfoDetailResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamInfoDetailResponse.java
@@ -1,0 +1,18 @@
+package com.pawith.todoapplication.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TodoTeamInfoDetailResponse {
+    private String todoTeamCode;
+    private String teamDescription;
+    private Integer teamMemberCount;
+    private Integer teamPetCount;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/WithdrawTodoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/WithdrawTodoResponse.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WithdrawTodoResponse {
+    private Long categoryId;
     private String categoryName;
     private String task;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoTeamMapper.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoTeamMapper.java
@@ -1,6 +1,7 @@
 package com.pawith.todoapplication.mapper;
 
 import com.pawith.todoapplication.dto.request.TodoTeamCreateRequest;
+import com.pawith.todoapplication.dto.response.TodoTeamInfoDetailResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
@@ -49,5 +50,14 @@ public class TodoTeamMapper {
 
     public static TodoTeamRandomCodeResponse mapToTodoTeamRandomCodeResponse(final TodoTeam todoTeam) {
         return new TodoTeamRandomCodeResponse(todoTeam.getTeamCode());
+    }
+
+    public static TodoTeamInfoDetailResponse mapToTodoTeamInfoDetailResponse(final TodoTeam todoTeam, final Integer registerCount, final Integer petCount) {
+        return TodoTeamInfoDetailResponse.builder()
+                .todoTeamCode(todoTeam.getTeamCode())
+                .teamDescription(todoTeam.getDescription())
+                .teamMemberCount(registerCount)
+                .teamPetCount(petCount)
+                .build();
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/ChangeRegisterUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/ChangeRegisterUseCase.java
@@ -38,4 +38,9 @@ public class ChangeRegisterUseCase {
         register.updateAuthority(authority);
     }
 
+    public void changeRegistered(Long registerId) {
+        Register register = registerQueryService.findRegisterById(registerId);
+        register.unregister();
+    }
+
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/PetChangeUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/PetChangeUseCase.java
@@ -1,0 +1,26 @@
+package com.pawith.todoapplication.service;
+
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.imagemodule.service.ImageUploadService;
+import com.pawith.todoapplication.dto.request.PetInfoChangeRequest;
+import com.pawith.tododomain.entity.Pet;
+import com.pawith.tododomain.service.PetQueryService;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional
+public class PetChangeUseCase {
+    private final PetQueryService petQueryService;
+    private final ImageUploadService imageUploadService;
+
+    public void updatePet(Long petId, MultipartFile teamImageFile, PetInfoChangeRequest request) {
+        CompletableFuture<String> teamImageAsync = imageUploadService.uploadImgAsync(teamImageFile);
+        Pet pet = petQueryService.findPetById(petId);
+        pet.updatePet(teamImageAsync.join(), request.getName(), request.getAge(), request.getGenus(), request.getSpecies(), request.getDescription());
+    }
+
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/PetCreateUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/PetCreateUseCase.java
@@ -1,0 +1,30 @@
+package com.pawith.todoapplication.service;
+
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.imagemodule.service.ImageUploadService;
+import com.pawith.todoapplication.dto.request.PetRegisterRequest;
+import com.pawith.todoapplication.mapper.PetMapper;
+import com.pawith.tododomain.entity.Pet;
+import com.pawith.tododomain.entity.TodoTeam;
+import com.pawith.tododomain.service.PetSaveService;
+import com.pawith.tododomain.service.TodoTeamQueryService;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional
+public class PetCreateUseCase {
+    private final PetSaveService petSaveService;
+    private final TodoTeamQueryService todoTeamQueryService;
+    private final ImageUploadService imageUploadService;
+
+    public void createPet(Long todoTeamId, MultipartFile petImageFile, PetRegisterRequest petRegisterRequest) {
+        final TodoTeam todoTeam = todoTeamQueryService.findTodoTeamById(todoTeamId);
+        CompletableFuture<String> petImageAsync = imageUploadService.uploadImgAsync(petImageFile);
+        final Pet pet = PetMapper.mapToPet(petRegisterRequest, todoTeam, petImageAsync.join());
+        petSaveService.savePetEntity(pet);
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/PetDeleteUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/PetDeleteUseCase.java
@@ -1,0 +1,18 @@
+package com.pawith.todoapplication.service;
+
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.tododomain.service.PetDeleteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional
+public class PetDeleteUseCase {
+
+    private final PetDeleteService petDeleteService;
+
+    public void deletePet(Long petId) {
+        petDeleteService.deletePet(petId);
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/PetGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/PetGetUseCase.java
@@ -1,0 +1,28 @@
+package com.pawith.todoapplication.service;
+
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.commonmodule.response.ListResponse;
+import com.pawith.todoapplication.dto.response.PetInfoResponse;
+import com.pawith.tododomain.entity.Pet;
+import com.pawith.tododomain.service.PetQueryService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PetGetUseCase {
+    private final PetQueryService petQueryService;
+
+    public ListResponse<PetInfoResponse> getTodoTeamPets(Long todoTeamId) {
+        List<Pet> pets = petQueryService.findAllByTodoTeamId(todoTeamId);
+        return ListResponse.from(
+                pets.stream()
+                        .map(pet -> new PetInfoResponse(pet.getId(), pet.getImageUrl(), pet.getName(), pet.getAge(),
+                                pet.getPetSpecies().getGenus(), pet.getPetSpecies().getSpecies(),pet.getDescription()))
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -84,7 +84,7 @@ public class TodoGetUseCase {
         final User user = userUtils.getAccessUser();
         final Slice<WithdrawTodoResponse> withdrawTodoResponses =
                 todoQueryService.findAllTodoListByTodoTeamId(user.getId(), todoTeamId, pageable)
-                        .map(todo -> new WithdrawTodoResponse(todo.getCategory().getName(), todo.getDescription()));
+                        .map(todo -> new WithdrawTodoResponse(todo.getCategory().getId(), todo.getCategory().getName(), todo.getDescription()));
         return SliceResponse.from(withdrawTodoResponses);
     }
 

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamChangeUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamChangeUseCase.java
@@ -1,0 +1,28 @@
+package com.pawith.todoapplication.service;
+
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.imagemodule.service.ImageUploadService;
+import com.pawith.todoapplication.dto.request.TodoTeamInfoChangeRequest;
+import com.pawith.tododomain.entity.TodoTeam;
+import com.pawith.tododomain.service.PetQueryService;
+import com.pawith.tododomain.service.TodoTeamQueryService;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional
+public class TodoTeamChangeUseCase {
+
+    private final ImageUploadService imageUploadService;
+    private final TodoTeamQueryService todoTeamQueryService;
+
+    public void updateTodoTeam(Long todoTeamId, MultipartFile teamImageFile, TodoTeamInfoChangeRequest request) {
+        CompletableFuture<String> teamImageAsync = imageUploadService.uploadImgAsync(teamImageFile);
+        TodoTeam todoTeam = todoTeamQueryService.findTodoTeamById(todoTeamId);
+        todoTeam.updateTodoTeam(request.getTeamName(), request.getDescription(), teamImageAsync.join());
+    }
+
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
@@ -3,6 +3,7 @@ package com.pawith.todoapplication.service;
 import com.pawith.commonmodule.annotation.ApplicationService;
 import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.commonmodule.response.SliceResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamInfoDetailResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
@@ -11,6 +12,7 @@ import com.pawith.todoapplication.dto.response.WithdrawTodoTeamResponse;
 import com.pawith.todoapplication.mapper.TodoTeamMapper;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.entity.TodoTeam;
+import com.pawith.tododomain.service.PetQueryService;
 import com.pawith.tododomain.service.RegisterQueryService;
 import com.pawith.tododomain.service.TodoTeamQueryService;
 import com.pawith.userdomain.entity.User;
@@ -33,6 +35,7 @@ public class TodoTeamGetUseCase {
     private final RegisterQueryService registerQueryService;
     private final TodoTeamQueryService todoTeamQueryService;
     private final UserQueryService userQueryService;
+    private final PetQueryService petQueryService;
 
 
     public SliceResponse<TodoTeamInfoResponse> getTodoTeams(final Pageable pageable) {
@@ -74,5 +77,12 @@ public class TodoTeamGetUseCase {
                         .map(todoTeam -> new WithdrawTodoTeamResponse(todoTeam.getImageUrl(), todoTeam.getTeamName()))
                         .collect(Collectors.toList())
         );
+    }
+
+    public TodoTeamInfoDetailResponse getTodoTeamInfo(Long todoTeamId) {
+        TodoTeam todoTeam = todoTeamQueryService.findTodoTeamById(todoTeamId);
+        Integer registerCount = registerQueryService.countRegisterByTodoTeamId(todoTeamId);
+        Integer petCount = petQueryService.countPetByTodoTeamId(todoTeamId);
+        return TodoTeamMapper.mapToTodoTeamInfoDetailResponse(todoTeam, registerCount, petCount);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
@@ -25,6 +25,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 @ApplicationService
 @RequiredArgsConstructor

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoTeamGetUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoTeamGetUseCaseTest.java
@@ -10,6 +10,7 @@ import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
 import com.pawith.tododomain.entity.Register;
 import com.pawith.tododomain.entity.TodoTeam;
+import com.pawith.tododomain.service.PetQueryService;
 import com.pawith.tododomain.service.RegisterQueryService;
 import com.pawith.tododomain.service.TodoTeamQueryService;
 import com.pawith.userdomain.entity.User;
@@ -41,12 +42,14 @@ public class TodoTeamGetUseCaseTest {
     private TodoTeamQueryService todoTeamQueryService;
     @Mock
     private UserQueryService userQueryService;
+    @Mock
+    private PetQueryService petQueryService;
 
     private TodoTeamGetUseCase todoTeamGetUseCase;
 
     @BeforeEach
     void init() {
-        todoTeamGetUseCase = new TodoTeamGetUseCase(userUtils, registerQueryService, todoTeamQueryService, userQueryService);
+        todoTeamGetUseCase = new TodoTeamGetUseCase(userUtils, registerQueryService, todoTeamQueryService, userQueryService, petQueryService);
     }
 
     @Test

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Pet.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Pet.java
@@ -2,6 +2,7 @@ package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
 import com.pawith.tododomain.entity.vo.PetSpecies;
+import java.util.Objects;
 import lombok.*;
 
 import javax.persistence.*;
@@ -35,5 +36,18 @@ public class Pet extends BaseEntity {
         this.imageUrl = imageUrl;
         this.petSpecies = petSpecies;
         this.todoTeam = todoTeam;
+    }
+
+
+    public void updatePet(String imageUrl, String name, Integer age, String description, String species, String genus) {
+        this.imageUrl = updateIfDifferent(imageUrl, this.imageUrl);
+        this.name = updateIfDifferent(name, this.name);
+        this.age = updateIfDifferent(age, this.age);
+        this.description = updateIfDifferent(description, this.description);
+        this.petSpecies.updatePetSpecies(genus, species);
+    }
+
+    public <T> T updateIfDifferent(T newValue, T currentValue) {
+        return Objects.equals(newValue, currentValue) ? currentValue : Objects.requireNonNullElse(newValue, currentValue);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Pet.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Pet.java
@@ -6,10 +6,14 @@ import java.util.Objects;
 import lombok.*;
 
 import javax.persistence.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE pet SET is_deleted = true WHERE pet_id = ?")
+@Where(clause = "is_deleted = false")
 public class Pet extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,6 +27,8 @@ public class Pet extends BaseEntity {
 
     @Embedded
     private PetSpecies petSpecies;
+
+    private Boolean isDeleted=Boolean.FALSE;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/TodoTeam.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/TodoTeam.java
@@ -1,6 +1,7 @@
 package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
+import java.util.Objects;
 import lombok.*;
 
 import javax.persistence.*;
@@ -27,4 +28,15 @@ public class TodoTeam extends BaseEntity {
         this.imageUrl = imageUrl;
         this.description = description;
     }
+
+    public void updateTodoTeam(String teamName, String description, String imageUrl) {
+        this.teamName = updateIfDifferent(teamName, this.teamName);
+        this.description = updateIfDifferent(description, this.description);
+        this.imageUrl = updateIfDifferent(imageUrl, this.imageUrl);
+    }
+
+    public <T> T updateIfDifferent(T newValue, T currentValue) {
+        return Objects.equals(newValue, currentValue) ? currentValue : Objects.requireNonNullElse(newValue, currentValue);
+    }
+
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/vo/PetSpecies.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/vo/PetSpecies.java
@@ -2,11 +2,13 @@ package com.pawith.tododomain.entity.vo;
 
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
 
 @Embeddable
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PetSpecies {
     private String genus; // 과

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/vo/PetSpecies.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/vo/PetSpecies.java
@@ -1,5 +1,6 @@
 package com.pawith.tododomain.entity.vo;
 
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,5 +19,14 @@ public class PetSpecies {
     public PetSpecies(String genus, String species) {
         this.genus = genus;
         this.species = species;
+    }
+
+    public void updatePetSpecies(String genus, String species) {
+        this.genus = updateIfDifferent(genus, this.genus);
+        this.species = updateIfDifferent(species, this.species);
+    }
+
+    public <T> T updateIfDifferent(T newValue, T currentValue) {
+        return Objects.equals(newValue, currentValue) ? currentValue : Objects.requireNonNullElse(newValue, currentValue);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/PetRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/PetRepository.java
@@ -4,4 +4,5 @@ import com.pawith.tododomain.entity.Pet;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PetRepository extends JpaRepository<Pet, Long> {
+    Integer countByTodoTeamId(Long todoTeamId);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/PetRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/PetRepository.java
@@ -1,8 +1,10 @@
 package com.pawith.tododomain.repository;
 
 import com.pawith.tododomain.entity.Pet;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PetRepository extends JpaRepository<Pet, Long> {
     Integer countByTodoTeamId(Long todoTeamId);
+    List<Pet> findAllByTodoTeamId(Long todoTeamId);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
@@ -30,6 +30,7 @@ public interface RegisterRepository extends JpaRepository<Register, Long> {
 
     List<Register> findAllByUserId(Long userId);
 
+    @Query("select r from Register r where r.todoTeam.id = :todoTeamId and r.userId = :userId and r.isRegistered = true")
     Optional<Register> findByTodoTeamIdAndUserId(Long todoTeamId, Long userId);
 
     Optional<Register> findByTodoTeamIdAndAuthority(Long todoTeamId, Authority authority);

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoRepository.java
@@ -23,8 +23,8 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     @Query(value = "select count(t) " +
         "from Todo t " +
         "join Register r on r.userId=:userId and r.todoTeam.id=:todoTeamId " +
-        "join Assign  a on a.register.id=r.id " +
-        "where a.todo.id=t.id and t.scheduledDate = :scheduledDate and t.completionStatus='COMPLETE'"
+        "join Assign  a on a.register.id=r.id and a.completionStatus='COMPLETE'" +
+        "where a.todo.id=t.id and t.scheduledDate = :scheduledDate"
     )
     Long countCompleteTodoByDate(@Param("userId") Long userId, @Param("todoTeamId") Long todoTeamId, @Param("scheduledDate") LocalDate scheduledDate);
 

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/PetDeleteService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/PetDeleteService.java
@@ -1,0 +1,18 @@
+package com.pawith.tododomain.service;
+
+import com.pawith.commonmodule.annotation.DomainService;
+import com.pawith.tododomain.repository.PetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@RequiredArgsConstructor
+@Transactional
+public class PetDeleteService {
+
+    private final PetRepository petRepository;
+
+    public void deletePet(Long petId) {
+        petRepository.deleteById(petId);
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/PetQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/PetQueryService.java
@@ -1,0 +1,18 @@
+package com.pawith.tododomain.service;
+
+import com.pawith.commonmodule.annotation.DomainService;
+import com.pawith.tododomain.repository.PetRepository;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+@Transactional
+public class PetQueryService {
+    private final PetRepository petRepository;
+
+    public Integer countPetByTodoTeamId(Long todoTeamId){
+        return petRepository.countByTodoTeamId(todoTeamId);
+    }
+
+}

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/PetQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/PetQueryService.java
@@ -19,4 +19,7 @@ public class PetQueryService {
     public List<Pet> findAllByTodoTeamId(Long todoTeamId){
         return petRepository.findAllByTodoTeamId(todoTeamId);
     }
+    public Pet findPetById(Long petId) {
+        return petRepository.findById(petId).orElseThrow();
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/PetQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/PetQueryService.java
@@ -1,7 +1,9 @@
 package com.pawith.tododomain.service;
 
 import com.pawith.commonmodule.annotation.DomainService;
+import com.pawith.tododomain.entity.Pet;
 import com.pawith.tododomain.repository.PetRepository;
+import java.util.List;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
@@ -14,5 +16,7 @@ public class PetQueryService {
     public Integer countPetByTodoTeamId(Long todoTeamId){
         return petRepository.countByTodoTeamId(todoTeamId);
     }
-
+    public List<Pet> findAllByTodoTeamId(Long todoTeamId){
+        return petRepository.findAllByTodoTeamId(todoTeamId);
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -192,6 +192,10 @@ operation::register-controller-test/unregister-todo-team[snippets='http-request,
 
 operation::register-controller-test/get-register-term[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 
+[[Todo-팀-가입자-내보내기]]
+=== Todo 팀 가입자 내보내기
+
+operation::register-controller-test/unregister-register[snippets='http-request,path-parameters,request-headers,http-response']
 [[PET-API]]
 == PET API
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -200,3 +200,8 @@ operation::pet-controller-test/get-todo-team-pets[snippets='http-request,path-pa
 === PET 생성
 
 operation::pet-controller-test/post-todo-team-pet[snippets='http-request,request-fields,request-headers,http-response']
+
+[[PET-삭제]]
+=== PET 삭제
+
+operation::pet-controller-test/delete-todo-team-pet[snippets='http-request,path-parameters,request-headers,http-response']

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -205,3 +205,8 @@ operation::pet-controller-test/post-todo-team-pet[snippets='http-request,request
 === PET 삭제
 
 operation::pet-controller-test/delete-todo-team-pet[snippets='http-request,path-parameters,request-headers,http-response']
+
+[[PET-정보-수정]]
+=== PET 정보 수정
+
+operation::pet-controller-test/put-todo-team-pet[snippets='http-request,path-parameters,request-headers,request-fields,http-response']

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -46,6 +46,10 @@ operation::todo-team-controller-test/get-withdraw-todo-team[snippets='http-reque
 
 operation::todo-team-controller-test/get-todo-team-info[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 
+[[Todo-Team-정보-수정]]
+=== Todo Team 정보 수정
+
+operation::todo-team-controller-test/put-todo-team-info[snippets='http-request,path-parameters,request-headers,request-fields,http-response']
 [[Todo-API]]
 == Todo API
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -187,3 +187,11 @@ operation::register-controller-test/unregister-todo-team[snippets='http-request,
 === Todo 팀 가입 기간 조회
 
 operation::register-controller-test/get-register-term[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
+[[PET-API]]
+== PET API
+
+[[PET-조회]]
+=== PET 조회
+
+operation::pet-controller-test/get-todo-team-pets[snippets='http-request,path-parameters,request-headers,http-response,response-fields']

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -41,6 +41,11 @@ operation::todo-team-controller-test/get-todo-team-by-code[snippets='http-reques
 
 operation::todo-team-controller-test/get-withdraw-todo-team[snippets='http-request,request-headers,http-response,response-fields']
 
+[[Todo-Team-상세-정보-조회]]
+=== Todo Team 상세 정보 조회
+
+operation::todo-team-controller-test/get-todo-team-info[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
 [[Todo-API]]
 == Todo API
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -195,3 +195,8 @@ operation::register-controller-test/get-register-term[snippets='http-request,pat
 === PET 조회
 
 operation::pet-controller-test/get-todo-team-pets[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
+[[PET-생성]]
+=== PET 생성
+
+operation::pet-controller-test/post-todo-team-pet[snippets='http-request,request-fields,request-headers,http-response']

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/PetController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/PetController.java
@@ -1,21 +1,32 @@
 package com.pawith.todopresentation;
 
 import com.pawith.commonmodule.response.ListResponse;
+import com.pawith.todoapplication.dto.request.PetRegisterRequest;
 import com.pawith.todoapplication.dto.response.PetInfoResponse;
+import com.pawith.todoapplication.service.PetCreateUseCase;
 import com.pawith.todoapplication.service.PetGetUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/teams")
 public class PetController {
+    private final PetCreateUseCase petCreateUseCase;
     private final PetGetUseCase petGetUseCase;
+    @PostMapping("/{todoTeamId}/pet")
+    public void postTodoTeamPet(@PathVariable Long todoTeamId, @RequestPart(value = "petImageFile") MultipartFile petImageFile,
+                                @RequestPart(value = "petInfo") PetRegisterRequest petRegisterRequest) {
+        petCreateUseCase.createPet(todoTeamId, petImageFile, petRegisterRequest);
+    }
 
     @GetMapping("/{todoTeamId}/pet")
     public ListResponse<PetInfoResponse> getTodoTeamPets(@PathVariable Long todoTeamId) {

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/PetController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/PetController.java
@@ -4,9 +4,11 @@ import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.todoapplication.dto.request.PetRegisterRequest;
 import com.pawith.todoapplication.dto.response.PetInfoResponse;
 import com.pawith.todoapplication.service.PetCreateUseCase;
+import com.pawith.todoapplication.service.PetDeleteUseCase;
 import com.pawith.todoapplication.service.PetGetUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +24,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class PetController {
     private final PetCreateUseCase petCreateUseCase;
     private final PetGetUseCase petGetUseCase;
+    private final PetDeleteUseCase petDeleteUseCase;
+
     @PostMapping("/{todoTeamId}/pet")
     public void postTodoTeamPet(@PathVariable Long todoTeamId, @RequestPart(value = "petImageFile") MultipartFile petImageFile,
                                 @RequestPart(value = "petCreateInfo") PetRegisterRequest petRegisterRequest) {
@@ -32,4 +36,10 @@ public class PetController {
     public ListResponse<PetInfoResponse> getTodoTeamPets(@PathVariable Long todoTeamId) {
         return petGetUseCase.getTodoTeamPets(todoTeamId);
     }
+
+    @DeleteMapping("pet/{petId}")
+    public void deleteTodoTeamPet(@PathVariable Long petId) {
+        petDeleteUseCase.deletePet(petId);
+    }
+
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/PetController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/PetController.java
@@ -1,8 +1,10 @@
 package com.pawith.todopresentation;
 
 import com.pawith.commonmodule.response.ListResponse;
+import com.pawith.todoapplication.dto.request.PetInfoChangeRequest;
 import com.pawith.todoapplication.dto.request.PetRegisterRequest;
 import com.pawith.todoapplication.dto.response.PetInfoResponse;
+import com.pawith.todoapplication.service.PetChangeUseCase;
 import com.pawith.todoapplication.service.PetCreateUseCase;
 import com.pawith.todoapplication.service.PetDeleteUseCase;
 import com.pawith.todoapplication.service.PetGetUseCase;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,6 +28,7 @@ public class PetController {
     private final PetCreateUseCase petCreateUseCase;
     private final PetGetUseCase petGetUseCase;
     private final PetDeleteUseCase petDeleteUseCase;
+    private final PetChangeUseCase petChangeUseCase;
 
     @PostMapping("/{todoTeamId}/pet")
     public void postTodoTeamPet(@PathVariable Long todoTeamId, @RequestPart(value = "petImageFile") MultipartFile petImageFile,
@@ -42,4 +46,9 @@ public class PetController {
         petDeleteUseCase.deletePet(petId);
     }
 
+    @PostMapping("pet/{petId}")
+    public void putTodoTeamPet(@PathVariable Long petId, @RequestPart(value = "petImageFile", required = false) MultipartFile petImageFile,
+                               @RequestPart(value = "petUpdateInfo", required = false) PetInfoChangeRequest petInfoChangeRequest) {
+        petChangeUseCase.updatePet(petId, petImageFile, petInfoChangeRequest);
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/PetController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/PetController.java
@@ -24,7 +24,7 @@ public class PetController {
     private final PetGetUseCase petGetUseCase;
     @PostMapping("/{todoTeamId}/pet")
     public void postTodoTeamPet(@PathVariable Long todoTeamId, @RequestPart(value = "petImageFile") MultipartFile petImageFile,
-                                @RequestPart(value = "petInfo") PetRegisterRequest petRegisterRequest) {
+                                @RequestPart(value = "petCreateInfo") PetRegisterRequest petRegisterRequest) {
         petCreateUseCase.createPet(todoTeamId, petImageFile, petRegisterRequest);
     }
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/PetController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/PetController.java
@@ -1,0 +1,24 @@
+package com.pawith.todopresentation;
+
+import com.pawith.commonmodule.response.ListResponse;
+import com.pawith.todoapplication.dto.response.PetInfoResponse;
+import com.pawith.todoapplication.service.PetGetUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/teams")
+public class PetController {
+    private final PetGetUseCase petGetUseCase;
+
+    @GetMapping("/{todoTeamId}/pet")
+    public ListResponse<PetInfoResponse> getTodoTeamPets(@PathVariable Long todoTeamId) {
+        return petGetUseCase.getTodoTeamPets(todoTeamId);
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
@@ -58,5 +58,10 @@ public class RegisterController {
         return registersGetUseCase.searchRegisterByNickname(todoTeamId, nickname);
     }
 
+    @PutMapping("/registers/{registerId}")
+    public void putRegister(@PathVariable Long registerId) {
+        changeRegisterUseCase.changeRegistered(registerId);
+    }
+
 
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
@@ -3,6 +3,7 @@ package com.pawith.todopresentation;
 import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.commonmodule.response.SliceResponse;
 import com.pawith.todoapplication.dto.request.TodoTeamCreateRequest;
+import com.pawith.todoapplication.dto.response.TodoTeamInfoDetailResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
@@ -66,5 +67,10 @@ public class TodoTeamController {
     @GetMapping("/withdraw")
     public ListResponse<WithdrawTodoTeamResponse> getWithdrawTodoTeamList() {
         return todoTeamGetUseCase.getWithdrawTodoTeam();
+    }
+
+    @GetMapping("/{todoTeamId}")
+    public TodoTeamInfoDetailResponse getTodoTeamInfo(@PathVariable Long todoTeamId) {
+        return todoTeamGetUseCase.getTodoTeamInfo(todoTeamId);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
@@ -77,7 +77,7 @@ public class TodoTeamController {
         return todoTeamGetUseCase.getTodoTeamInfo(todoTeamId);
     }
 
-    @PutMapping("/{todoTeamId}")
+    @PostMapping("/{todoTeamId}")
     public void putTodoTeamInfo (@PathVariable Long todoTeamId, @RequestPart(value = "teamImageFile", required = false) MultipartFile teamImageFile,
                                  @RequestPart(value = "todoTeamUpdateInfo", required = false) TodoTeamInfoChangeRequest todoTeamInfoChangeRequest) {
         todoTeamChangeUseCase.updateTodoTeam(todoTeamId, teamImageFile, todoTeamInfoChangeRequest);

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoTeamController.java
@@ -3,12 +3,14 @@ package com.pawith.todopresentation;
 import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.commonmodule.response.SliceResponse;
 import com.pawith.todoapplication.dto.request.TodoTeamCreateRequest;
+import com.pawith.todoapplication.dto.request.TodoTeamInfoChangeRequest;
 import com.pawith.todoapplication.dto.response.TodoTeamInfoDetailResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
 import com.pawith.todoapplication.dto.response.WithdrawTodoTeamResponse;
+import com.pawith.todoapplication.service.TodoTeamChangeUseCase;
 import com.pawith.todoapplication.service.TodoTeamCreateUseCase;
 import com.pawith.todoapplication.service.TodoTeamGetUseCase;
 import com.pawith.todoapplication.service.TodoTeamRandomCodeGetUseCase;
@@ -31,6 +33,7 @@ public class TodoTeamController {
     private final TodoTeamGetUseCase todoTeamGetUseCase;
     private final TodoTeamRandomCodeGetUseCase todoTeamRandomCodeGetUseCase;
     private final TodoTeamCreateUseCase todoTeamCreateUseCase;
+    private final TodoTeamChangeUseCase todoTeamChangeUseCase;
 
     @GetMapping
     public SliceResponse<TodoTeamInfoResponse> getTodoTeams(Pageable pageable) {
@@ -72,5 +75,11 @@ public class TodoTeamController {
     @GetMapping("/{todoTeamId}")
     public TodoTeamInfoDetailResponse getTodoTeamInfo(@PathVariable Long todoTeamId) {
         return todoTeamGetUseCase.getTodoTeamInfo(todoTeamId);
+    }
+
+    @PutMapping("/{todoTeamId}")
+    public void putTodoTeamInfo (@PathVariable Long todoTeamId, @RequestPart(value = "teamImageFile", required = false) MultipartFile teamImageFile,
+                                 @RequestPart(value = "todoTeamUpdateInfo", required = false) TodoTeamInfoChangeRequest todoTeamInfoChangeRequest) {
+        todoTeamChangeUseCase.updateTodoTeam(todoTeamId, teamImageFile, todoTeamInfoChangeRequest);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/PetControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/PetControllerTest.java
@@ -3,6 +3,7 @@ package com.pawith.todopresentation;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -19,6 +20,7 @@ import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
 import com.pawith.todoapplication.dto.response.PetInfoResponse;
 import com.pawith.todoapplication.service.PetCreateUseCase;
+import com.pawith.todoapplication.service.PetDeleteUseCase;
 import com.pawith.todoapplication.service.PetGetUseCase;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +41,8 @@ public class PetControllerTest extends BaseRestDocsTest {
     private PetGetUseCase petGetUseCase;
     @MockBean
     private PetCreateUseCase petCreateUseCase;
+    @MockBean
+    private PetDeleteUseCase petDeleteUseCase;
 
     private static final String PET_REQUEST_URL = "/teams";
     private static final String PET_TEAM_CREATE_INFO = "{\n" +
@@ -53,7 +57,7 @@ public class PetControllerTest extends BaseRestDocsTest {
     @DisplayName("팀의 펫 정보 조회 API 테스트")
     void getTodoTeamPets() throws Exception {
         // given
-        final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
+        final Long testTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
         final List<PetInfoResponse> petInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(PetInfoResponse.class, 2);
         given(petGetUseCase.getTodoTeamPets(testTeamId)).willReturn(ListResponse.from(petInfoResponses));
         MockHttpServletRequestBuilder request = get(PET_REQUEST_URL + "/{todoTeamId}/pet", testTeamId)
@@ -86,7 +90,7 @@ public class PetControllerTest extends BaseRestDocsTest {
     @DisplayName("펫 정보 저장 API 테스트")
     void postTodoTeamPet() throws Exception {
         // given
-        final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
+        final Long testTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
         final MockMultipartFile mockMultipartFilePet = new MockMultipartFile("petImageFile", "petImageFile", "image/jpeg", "image".getBytes());
         final MockMultipartFile petCreateInfo = new MockMultipartFile("petCreateInfo", "", MediaType.APPLICATION_JSON_VALUE, PET_TEAM_CREATE_INFO.getBytes());
         MockHttpServletRequestBuilder request = multipart(PET_REQUEST_URL + "/{todoTeamId}/pet", testTeamId)
@@ -111,6 +115,27 @@ public class PetControllerTest extends BaseRestDocsTest {
                                 fieldWithPath("petGenus").description("Pet의 종"),
                                 fieldWithPath("petSpecies").description("Pet의 품종"),
                                 fieldWithPath("description").description("Pet의 설명")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("펫 정보 삭제 API 테스트")
+    void deleteTodoTeamPet() throws Exception {
+        // given
+        final Long testPetId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        MockHttpServletRequestBuilder request = delete(PET_REQUEST_URL + "/pet/{petId}", testPetId)
+                .header("Authorization", "Bearer accessToken");
+        // when
+        ResultActions result = mvc.perform(request);
+        // then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("petId").description("Pet의 Id")
                         )
                 ));
     }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/PetControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/PetControllerTest.java
@@ -4,7 +4,11 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
@@ -13,8 +17,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
-import com.pawith.todoapplication.dto.response.CategoryInfoResponse;
 import com.pawith.todoapplication.dto.response.PetInfoResponse;
+import com.pawith.todoapplication.service.PetCreateUseCase;
 import com.pawith.todoapplication.service.PetGetUseCase;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +26,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -31,8 +37,17 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 public class PetControllerTest extends BaseRestDocsTest {
     @MockBean
     private PetGetUseCase petGetUseCase;
+    @MockBean
+    private PetCreateUseCase petCreateUseCase;
 
     private static final String PET_REQUEST_URL = "/teams";
+    private static final String PET_TEAM_CREATE_INFO = "{\n" +
+            "        \"name\" : \"이름이 뭐에요~\",\n" +
+            "        \"age\" : 2,\n" +
+            "        \"description\" : \"귀엽습니다\",\n" +
+            "        \"petGenus\" : \"과\",\n" +
+            "        \"petSpecies\" : \"종\"\n" +
+            "    }";
 
     @Test
     @DisplayName("팀의 펫 정보 조회 API 테스트")
@@ -63,6 +78,39 @@ public class PetControllerTest extends BaseRestDocsTest {
                                 fieldWithPath("content[].petGenus").description("Pet의 종"),
                                 fieldWithPath("content[].petSpecies").description("Pet의 품종"),
                                 fieldWithPath("content[].petDescription").description("Pet의 설명")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("펫 정보 저장 API 테스트")
+    void postTodoTeamPet() throws Exception {
+        // given
+        final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
+        final MockMultipartFile mockMultipartFilePet = new MockMultipartFile("petImageFile", "petImageFile", "image/jpeg", "image".getBytes());
+        final MockMultipartFile petCreateInfo = new MockMultipartFile("petCreateInfo", "", MediaType.APPLICATION_JSON_VALUE, PET_TEAM_CREATE_INFO.getBytes());
+        MockHttpServletRequestBuilder request = multipart(PET_REQUEST_URL + "/{todoTeamId}/pet", testTeamId)
+                .file(mockMultipartFilePet)
+                .file(petCreateInfo)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer accessToken");
+        // when
+        ResultActions result = mvc.perform(request);
+        // then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("todoTeamId").description("TodoTeam의 Id")
+                        ),
+                        requestPartFields("petCreateInfo",
+                                fieldWithPath("name").description("Pet의 이름"),
+                                fieldWithPath("age").description("Pet의 나이"),
+                                fieldWithPath("petGenus").description("Pet의 종"),
+                                fieldWithPath("petSpecies").description("Pet의 품종"),
+                                fieldWithPath("description").description("Pet의 설명")
                         )
                 ));
     }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/PetControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/PetControllerTest.java
@@ -1,0 +1,70 @@
+package com.pawith.todopresentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.pawith.commonmodule.BaseRestDocsTest;
+import com.pawith.commonmodule.response.ListResponse;
+import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import com.pawith.todoapplication.dto.response.CategoryInfoResponse;
+import com.pawith.todoapplication.dto.response.PetInfoResponse;
+import com.pawith.todoapplication.service.PetGetUseCase;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@Slf4j
+@WebMvcTest(PetController.class)
+@DisplayName("PetController 테스트")
+public class PetControllerTest extends BaseRestDocsTest {
+    @MockBean
+    private PetGetUseCase petGetUseCase;
+
+    private static final String PET_REQUEST_URL = "/teams";
+
+    @Test
+    @DisplayName("팀의 펫 정보 조회 API 테스트")
+    void getTodoTeamPets() throws Exception {
+        // given
+        final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
+        final List<PetInfoResponse> petInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(PetInfoResponse.class, 2);
+        given(petGetUseCase.getTodoTeamPets(testTeamId)).willReturn(ListResponse.from(petInfoResponses));
+        MockHttpServletRequestBuilder request = get(PET_REQUEST_URL + "/{todoTeamId}/pet", testTeamId)
+                .header("Authorization", "Bearer accessToken");
+        // when
+        ResultActions result = mvc.perform(request);
+        // then
+        // then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("todoTeamId").description("TodoTeam의 Id")
+                        ),
+                        responseFields(
+                                fieldWithPath("content[].petId").description("Pet의 Id"),
+                                fieldWithPath("content[].imageUrl").description("Pet의 이미지 URL"),
+                                fieldWithPath("content[].petName").description("Pet의 이름"),
+                                fieldWithPath("content[].petAge").description("Pet의 나이"),
+                                fieldWithPath("content[].petGenus").description("Pet의 종"),
+                                fieldWithPath("content[].petSpecies").description("Pet의 품종"),
+                                fieldWithPath("content[].petDescription").description("Pet의 설명")
+                        )
+                ));
+    }
+
+}

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/PetControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/PetControllerTest.java
@@ -19,6 +19,7 @@ import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
 import com.pawith.todoapplication.dto.response.PetInfoResponse;
+import com.pawith.todoapplication.service.PetChangeUseCase;
 import com.pawith.todoapplication.service.PetCreateUseCase;
 import com.pawith.todoapplication.service.PetDeleteUseCase;
 import com.pawith.todoapplication.service.PetGetUseCase;
@@ -43,6 +44,8 @@ public class PetControllerTest extends BaseRestDocsTest {
     private PetCreateUseCase petCreateUseCase;
     @MockBean
     private PetDeleteUseCase petDeleteUseCase;
+    @MockBean
+    private PetChangeUseCase petChangeUseCase;
 
     private static final String PET_REQUEST_URL = "/teams";
     private static final String PET_TEAM_CREATE_INFO = "{\n" +
@@ -136,6 +139,39 @@ public class PetControllerTest extends BaseRestDocsTest {
                         ),
                         pathParameters(
                                 parameterWithName("petId").description("Pet의 Id")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("펫 정보 수정 API 테스트")
+    void putTodoTeamPet() throws Exception {
+        // given
+        final Long testPetId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        final MockMultipartFile mockMultipartFilePet = new MockMultipartFile("petImageFile", "petImageFile", "image/jpeg", "image".getBytes());
+        final MockMultipartFile petCreateInfo = new MockMultipartFile("petUpdateInfo", "", MediaType.APPLICATION_JSON_VALUE, PET_TEAM_CREATE_INFO.getBytes());
+        MockHttpServletRequestBuilder request = multipart(PET_REQUEST_URL + "/pet/{petId}", testPetId)
+                .file(mockMultipartFilePet)
+                .file(petCreateInfo)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer accessToken");
+        // when
+        ResultActions result = mvc.perform(request);
+        // then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("petId").description("Pet의 Id")
+                        ),
+                        requestPartFields("petUpdateInfo",
+                                fieldWithPath("name").description("Pet의 이름"),
+                                fieldWithPath("age").description("Pet의 나이"),
+                                fieldWithPath("petGenus").description("Pet의 종"),
+                                fieldWithPath("petSpecies").description("Pet의 품종"),
+                                fieldWithPath("description").description("Pet의 설명")
                         )
                 ));
     }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -239,4 +239,25 @@ class RegisterControllerTest extends BaseRestDocsTest {
                 )
             ));
     }
+
+    @Test
+    @DisplayName("TodoTeam의 가입자를 내보내는 API 테스트")
+    void unregisterRegister() throws Exception {
+        //given
+        final Long registerId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        MockHttpServletRequestBuilder request = put(REGISTER_REQUEST_URL + "/registers/{registerId}", registerId)
+            .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+            .andDo(resultHandler.document(
+                requestHeaders(
+                    headerWithName("Authorization").description("access 토큰")
+                ),
+                pathParameters(
+                    parameterWithName("registerId").description("내보낼 Register의 Id")
+                )
+            ));
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -85,18 +85,15 @@ public class TodoControllerTest extends BaseRestDocsTest {
     @DisplayName("할당받은 Todo 조회 API 테스트")
     void getTodos() throws Exception{
         //given
-        final PageRequest pageRequest = PageRequest.of(0, 6);
         final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
         final List<TodoInfoResponse> todoResponse = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
                 .giveMeBuilder(TodoInfoResponse.class)
                 .set("todoId", Arbitraries.longs().greaterOrEqual(1L))
                 .set("task", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(5).ofMaxLength(10))
                 .set("status", FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeBuilder("COMPLETE"))
-                .sampleList(pageRequest.getPageSize());
+                .sampleList(2);
         given(todoGetUseCase.getTodoListByTodoTeamId(any())).willReturn(ListResponse.from(todoResponse));
         MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/{todoTeamId}/todos", testTeamId)
-                .queryParam("page", String.valueOf(pageRequest.getPageNumber()))
-                .queryParam("size", String.valueOf(pageRequest.getPageSize()))
                 .header("Authorization", "Bearer accessToken");
         //when
         ResultActions result = mvc.perform(request);
@@ -108,10 +105,6 @@ public class TodoControllerTest extends BaseRestDocsTest {
                         ),
                         pathParameters(
                                 parameterWithName("todoTeamId").description("TodoTeam의 Id")
-                        ),
-                        requestParameters(
-                                parameterWithName("page").description("요청 페이지"),
-                                parameterWithName("size").description("요청 사이즈")
                         ),
                         responseFields(
                                 fieldWithPath("content[].todoId").description("투두 항목 Id"),
@@ -398,6 +391,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
                                 parameterWithName("size").description("요청 사이즈")
                         ),
                         responseFields(
+                                fieldWithPath("content[].categoryId").description("투두 항목 카테고리 Id"),
                                 fieldWithPath("content[].categoryName").description("투두 항목 카테고리 이름"),
                                 fieldWithPath("content[].task").description("투두 항목 이름"),
                                 fieldWithPath("page").description("요청 페이지"),

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -327,14 +327,13 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
         final MockMultipartFile mockMultipartFileTeam = new MockMultipartFile("teamImageFile", "teamImageFile", "image/jpeg", "image".getBytes());
         final MockMultipartFile todoTeamInfoChangeRequest = new MockMultipartFile("todoTeamUpdateInfo", "", MediaType.APPLICATION_JSON_VALUE, TODO_TEAM_UPDATE_INFO.getBytes());
         //when
-        ResultActions result = mvc.perform(
-                multipart(TODO_TEAM_REQUEST_URL + "/{todoTeamId}", todoTeamId, HttpMethod.PUT)
-                .file(mockMultipartFileTeam)
-                .file(todoTeamInfoChangeRequest)
-                .header("Authorization", "Bearer accessToken"))
-                .andExpect(status().isOk());
-
-
+        MockHttpServletRequestBuilder request = multipart(TODO_TEAM_REQUEST_URL+"/{todoTeamId}", todoTeamId)
+            .file(mockMultipartFileTeam)
+            .file(todoTeamInfoChangeRequest)
+            .accept(MediaType.APPLICATION_JSON)
+            .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
         //then
         result.andExpect(status().isOk())
             .andDo(resultHandler.document(

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -4,6 +4,7 @@ import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.commonmodule.response.SliceResponse;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
+import com.pawith.todoapplication.dto.response.TodoTeamInfoDetailResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
@@ -271,5 +272,35 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
                                 fieldWithPath("content[].teamName").description("TodoTeam의 이름")
                         )
                 ));
+    }
+
+    @Test
+    @DisplayName("TodoTeam 상세 정보 조회 API 테스트")
+    void getTodoTeamInfo() throws Exception {
+        //given
+        final Long todoTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        final TodoTeamInfoDetailResponse todoTeamInfoDetailResponse = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
+            .giveMeOne(TodoTeamInfoDetailResponse.class);
+        given(todoTeamGetUseCase.getTodoTeamInfo(todoTeamId)).willReturn(todoTeamInfoDetailResponse);
+        MockHttpServletRequestBuilder request = get(TODO_TEAM_REQUEST_URL+"/{todoTeamId}", todoTeamId)
+            .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+            .andDo(resultHandler.document(
+                requestHeaders(
+                    headerWithName("Authorization").description("access 토큰")
+                ),
+                pathParameters(
+                    parameterWithName("todoTeamId").description("TodoTeam의 Id")
+                ),
+                responseFields(
+                    fieldWithPath("todoTeamCode").description("TodoTeam의 코드"),
+                    fieldWithPath("teamDescription").description("TodoTeam의 설명"),
+                    fieldWithPath("teamMemberCount").description("TodoTeam의 가입자 수"),
+                    fieldWithPath("teamPetCount").description("TodoTeam의 펫 수")
+                )
+            ));
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -1,5 +1,6 @@
 package com.pawith.todopresentation;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.commonmodule.response.SliceResponse;
@@ -10,6 +11,7 @@ import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
 import com.pawith.todoapplication.dto.response.WithdrawTodoTeamResponse;
+import com.pawith.todoapplication.service.TodoTeamChangeUseCase;
 import com.pawith.todoapplication.service.TodoTeamCreateUseCase;
 import com.pawith.todoapplication.service.TodoTeamGetUseCase;
 import com.pawith.todoapplication.service.TodoTeamRandomCodeGetUseCase;
@@ -20,12 +22,15 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import java.util.List;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -33,9 +38,13 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.request;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.web.servlet.function.RequestPredicates.accept;
 
 @Slf4j
 @WebMvcTest(TodoTeamController.class)
@@ -64,12 +73,18 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
         "\n" +
         "    ]\n" +
         "}";
+    private static final String TODO_TEAM_UPDATE_INFO = "{\n" +
+        "    \"teamName\" : \"test\",\n" +
+        "    \"description\" : \"test\"\n" +
+        "}";
     @MockBean
     private TodoTeamGetUseCase todoTeamGetUseCase;
     @MockBean
     private TodoTeamRandomCodeGetUseCase todoTeamRandomCodeGetUseCase;
     @MockBean
     private TodoTeamCreateUseCase todoTeamCreateUseCase;
+    @MockBean
+    private TodoTeamChangeUseCase todoTeamChangeUseCase;
 
     @Test
     @DisplayName("TodoTeam 목록을 가져오는 테스트")
@@ -300,6 +315,38 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
                     fieldWithPath("teamDescription").description("TodoTeam의 설명"),
                     fieldWithPath("teamMemberCount").description("TodoTeam의 가입자 수"),
                     fieldWithPath("teamPetCount").description("TodoTeam의 펫 수")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("TodoTeam 정보 수정 API 테스트")
+    void putTodoTeamInfo() throws Exception {
+        //given
+        final Long todoTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        final MockMultipartFile mockMultipartFileTeam = new MockMultipartFile("teamImageFile", "teamImageFile", "image/jpeg", "image".getBytes());
+        final MockMultipartFile todoTeamInfoChangeRequest = new MockMultipartFile("todoTeamUpdateInfo", "", MediaType.APPLICATION_JSON_VALUE, TODO_TEAM_UPDATE_INFO.getBytes());
+        //when
+        ResultActions result = mvc.perform(
+                multipart(TODO_TEAM_REQUEST_URL + "/{todoTeamId}", todoTeamId, HttpMethod.PUT)
+                .file(mockMultipartFileTeam)
+                .file(todoTeamInfoChangeRequest)
+                .header("Authorization", "Bearer accessToken"))
+                .andExpect(status().isOk());
+
+
+        //then
+        result.andExpect(status().isOk())
+            .andDo(resultHandler.document(
+                requestHeaders(
+                    headerWithName("Authorization").description("access 토큰")
+                ),
+                pathParameters(
+                    parameterWithName("todoTeamId").description("TodoTeam의 Id")
+                ),
+                requestPartFields("todoTeamUpdateInfo",
+                    fieldWithPath("teamName").description("TodoTeam 이름"),
+                    fieldWithPath("description").description("TodoTeam 한줄설명")
                 )
             ));
     }


### PR DESCRIPTION
## 작업사항
- TodoTeam 상세 정보 조회, TodoTeam 정보 수정 API 추가, 테스트 코드 작성, 명세 반영
- Pet 정보 조회,생성,삭제,수정 API 추가, 테스트 코드 작성, 명세 반영 
- 관리자 페이지 중 회원관리 내보내기 기능 API 추가, 테스트 코드 작성, 명세 반영

## 변경로직
- TodoTeam 탈퇴 시 담당했던 Todo 정보 응답값에 categoryId 추가, 명세 반영
- 메인페이지용 Todo 조회 API 테스트 코드에 SliceResponse 관련 값들이 있어서 수정
- 관리자페이지에서 권한 수정 하는 기능에서 Register 찾는 쿼리에 필터링 추가
- 메인페이지 Todo 달성률 count 쿼리에 필터링 추가 

## 참고자료
- 내용을 적어주세요.



