### PR TITLE
Pet 176 refactor : 자바 11 -> 17로 변경 및 SpringBoot 버전 3으로 변경

### DIFF
--- a/.deploy/Dockerfile
+++ b/.deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:11
+FROM amazoncorretto:17
 ARG JAR_FILE=/Api-Module/build/libs/Api-Module-0.0.1.jar
 COPY ${JAR_FILE} pawith.jar
 ENTRYPOINT ["java","-Dcom.mysql.cj.disableAbandonedConnectionCleanup=true","-jar","/pawith.jar"]

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'corretto'
 
       - name: Gradle Caching

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'corretto'
 
       - name: Gradle Caching

--- a/Alarm-Module/src/docs/Alarm-API.adoc
+++ b/Alarm-Module/src/docs/Alarm-API.adoc
@@ -9,7 +9,7 @@ operation::alarm-controller-test/get-alarms-exist[snippets='http-request,request
 [[알림-조회]]
 === 알림 조회
 
-operation::alarm-controller-test/get-alarms[snippets='http-request,request-headers,request-parameters,http-response,response-fields']
+operation::alarm-controller-test/get-alarms[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
 
 [[device-token-저장]]
 === 디바이스 토큰 저장

--- a/Alarm-Module/src/main/java/com/pawith/alarmmodule/entity/Alarm.java
+++ b/Alarm-Module/src/main/java/com/pawith/alarmmodule/entity/Alarm.java
@@ -3,12 +3,12 @@ package com.pawith.alarmmodule.entity;
 import com.pawith.alarmmodule.entity.vo.AlarmBody;
 import com.pawith.commonmodule.domain.BaseEntity;
 import com.pawith.commonmodule.enums.AlarmCategory;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
 
 @Entity
 @Getter

--- a/Alarm-Module/src/main/java/com/pawith/alarmmodule/entity/AlarmUser.java
+++ b/Alarm-Module/src/main/java/com/pawith/alarmmodule/entity/AlarmUser.java
@@ -1,19 +1,20 @@
 package com.pawith.alarmmodule.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
 import java.util.Objects;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class AlarmUser extends BaseEntity {
-    @Id@GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "alarm_user_id")
     private Long id;
 

--- a/Alarm-Module/src/main/java/com/pawith/alarmmodule/entity/vo/AlarmBody.java
+++ b/Alarm-Module/src/main/java/com/pawith/alarmmodule/entity/vo/AlarmBody.java
@@ -1,10 +1,10 @@
 package com.pawith.alarmmodule.entity.vo;
 
+import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Embeddable;
 
 @Embeddable
 @Getter

--- a/Alarm-Module/src/test/java/com/pawith/alarmmodule/controller/AlarmControllerTest.java
+++ b/Alarm-Module/src/test/java/com/pawith/alarmmodule/controller/AlarmControllerTest.java
@@ -24,8 +24,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -83,7 +82,7 @@ class AlarmControllerTest extends BaseRestDocsTest {
                 requestHeaders(
                     headerWithName("Authorization").description("access 토큰")
                 ),
-                requestParameters(
+                queryParameters(
                     parameterWithName("page").description("페이지 번호"),
                     parameterWithName("size").description("페이지 크기")
                 ),

--- a/Common-Module/src/main/java/com/pawith/commonmodule/domain/BaseEntity.java
+++ b/Common-Module/src/main/java/com/pawith/commonmodule/domain/BaseEntity.java
@@ -2,7 +2,6 @@ package com.pawith.commonmodule.domain;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import java.util.Objects;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -21,7 +20,4 @@ public abstract class BaseEntity {
     @LastModifiedDate
     protected LocalDateTime updatedAt;
 
-    protected<T> T updateIfDifferent(T newValue, T currentValue) {
-        return Objects.equals(newValue, currentValue) ? currentValue : Objects.requireNonNullElse(newValue, currentValue);
-    }
 }

--- a/Common-Module/src/main/java/com/pawith/commonmodule/domain/BaseEntity.java
+++ b/Common-Module/src/main/java/com/pawith/commonmodule/domain/BaseEntity.java
@@ -1,12 +1,12 @@
 package com.pawith.commonmodule.domain;
 
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
 @Getter

--- a/Common-Module/src/main/java/com/pawith/commonmodule/response/ListResponse.java
+++ b/Common-Module/src/main/java/com/pawith/commonmodule/response/ListResponse.java
@@ -1,8 +1,9 @@
 package com.pawith.commonmodule.response;
 
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class ListResponse<T> {
@@ -10,7 +11,7 @@ public class ListResponse<T> {
     private final List<T> content;
 
     @Builder
-    public ListResponse(List<T> content) {
+    private ListResponse(List<T> content) {
         this.content = content;
     }
 

--- a/Common-Module/src/main/java/com/pawith/commonmodule/util/DomainFieldUtils.java
+++ b/Common-Module/src/main/java/com/pawith/commonmodule/util/DomainFieldUtils.java
@@ -1,0 +1,11 @@
+package com.pawith.commonmodule.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DomainFieldUtils {
+    public static <T> T updateIfDifferent(T newValue, T currentValue) {
+        return newValue.equals(currentValue) ? currentValue : newValue;
+    }
+}

--- a/Domain-Module/Auth-Module/Auth-Application/build.gradle
+++ b/Domain-Module/Auth-Module/Auth-Application/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     implementation project(':Domain-Module:Auth-Module:Auth-Domain')
     // Feign
     implementation 'io.github.openfeign:feign-httpclient:12.1'
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:3.1.8'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.3'
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/entity/Token.java
+++ b/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/entity/Token.java
@@ -2,6 +2,7 @@ package com.pawith.authdomain.entity;
 
 import com.pawith.authdomain.jwt.TokenType;
 import com.pawith.commonmodule.domain.BaseEntity;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +10,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import javax.persistence.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/jwt/JWTProperties.java
+++ b/Domain-Module/Auth-Module/Auth-Domain/src/main/java/com/pawith/authdomain/jwt/JWTProperties.java
@@ -3,11 +3,9 @@ package com.pawith.authdomain.jwt;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @Getter
 @RequiredArgsConstructor
-@ConstructorBinding
 @ConfigurationProperties(prefix = "jwt")
 public class JWTProperties {
     private final String secret;

--- a/Domain-Module/Auth-Module/Auth-Presentation/src/docs/asciidoc/Auth-API.adoc
+++ b/Domain-Module/Auth-Module/Auth-Presentation/src/docs/asciidoc/Auth-API.adoc
@@ -4,7 +4,7 @@
 [[Auth-소셜로그인]]
 === Auth 소셜 로그인
 
-operation::o-auth-controller-test/o-auth-login[snippets='http-request,path-parameters,request-parameters,http-response,response-fields']
+operation::o-auth-controller-test/o-auth-login[snippets='http-request,path-parameters,query-parameters,http-response,response-fields']
 
 [[Auth-로그아웃]]
 === Auth 로그아웃

--- a/Domain-Module/Auth-Module/Auth-Presentation/src/main/java/com/pawith/authpresentation/common/security/SecurityConfig.java
+++ b/Domain-Module/Auth-Module/Auth-Presentation/src/main/java/com/pawith/authpresentation/common/security/SecurityConfig.java
@@ -2,30 +2,33 @@ package com.pawith.authpresentation.common.security;
 
 import com.pawith.authpresentation.common.security.filter.JWTAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+@Configuration
 @EnableWebSecurity
 public class SecurityConfig {
     @Bean
     public SecurityFilterChain chain(HttpSecurity http) throws Exception {
-        http.cors().disable();
+        http.cors(AbstractHttpConfigurer::disable);
         http.addFilterBefore(SecurityHandler.getJWTAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
         http.addFilterBefore(SecurityHandler.getJWTEntryPoint(), JWTAuthenticationFilter.class);
 
-        http.csrf().disable();
+        http.csrf(AbstractHttpConfigurer::disable);
 
-        http.authorizeHttpRequests( request ->{
+        http.authorizeHttpRequests(request ->{
             request.anyRequest().permitAll();
         });
 
-        http.formLogin().disable();
-        http.httpBasic().disable();
-        http.logout().disable();
-        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http.formLogin(AbstractHttpConfigurer::disable);
+        http.httpBasic(AbstractHttpConfigurer::disable);
+        http.logout(AbstractHttpConfigurer::disable);
+        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
     }

--- a/Domain-Module/Auth-Module/Auth-Presentation/src/main/java/com/pawith/authpresentation/common/security/filter/JWTAuthenticationFilter.java
+++ b/Domain-Module/Auth-Module/Auth-Presentation/src/main/java/com/pawith/authpresentation/common/security/filter/JWTAuthenticationFilter.java
@@ -1,11 +1,15 @@
 package com.pawith.authpresentation.common.security.filter;
 
+import com.pawith.authapplication.consts.AuthConsts;
+import com.pawith.authapplication.consts.IgnoredPathConsts;
 import com.pawith.authapplication.service.JWTExtractEmailUseCase;
 import com.pawith.authapplication.service.JWTExtractTokenUseCase;
 import com.pawith.authapplication.service.JWTVerifyUseCase;
-import com.pawith.authapplication.consts.AuthConsts;
-import com.pawith.authapplication.consts.IgnoredPathConsts;
 import com.pawith.authpresentation.common.security.JWTAuthenticationToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -14,10 +18,6 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Set;
 

--- a/Domain-Module/Auth-Module/Auth-Presentation/src/main/java/com/pawith/authpresentation/common/security/filter/JWTEntryPoint.java
+++ b/Domain-Module/Auth-Module/Auth-Presentation/src/main/java/com/pawith/authpresentation/common/security/filter/JWTEntryPoint.java
@@ -3,14 +3,14 @@ package com.pawith.authpresentation.common.security.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawith.commonmodule.exception.BusinessException;
 import com.pawith.commonmodule.exception.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Component

--- a/Domain-Module/Auth-Module/Auth-Presentation/src/test/java/com/pawith/authpresentation/OAuthControllerTest.java
+++ b/Domain-Module/Auth-Module/Auth-Presentation/src/test/java/com/pawith/authpresentation/OAuthControllerTest.java
@@ -62,7 +62,7 @@ class OAuthControllerTest extends BaseRestDocsTest {
         result.andExpect(status().isOk())
             .andDo(print())
             .andDo(resultHandler.document(
-                requestParameters(
+                queryParameters(
                     parameterWithName(OAUTH_REQUEST_ACCESS_TOKEN_PARAM_NAME).description("OAuth 접근 토큰")
                 ),
                 pathParameters(

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategoryInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategoryInfoResponse.java
@@ -1,10 +1,13 @@
 package com.pawith.todoapplication.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CategoryInfoResponse {
     private Long categoryId;
     private String categoryName;

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/TodoNotificationHandler.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/TodoNotificationHandler.java
@@ -44,7 +44,7 @@ public class TodoNotificationHandler {
         boolean hasNext = true;
         do {
             final PageRequest pageRequest = PageRequest.of(page, BATCH_SIZE);
-            final Slice<NotificationDao> notificationBatch = todoNotificationRepository.findAllWithNotCompletedAssignAndTodayScheduledTodo(3, pageRequest);
+            final Slice<NotificationDao> notificationBatch = todoNotificationRepository.findAllWithNotCompletedAssignAndTodayScheduledTodo(Duration.ofHours(3), pageRequest);
             handleNotification(notificationBatch);
             hasNext = notificationBatch.hasNext();
             page++;

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/AssignChangeUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/AssignChangeUseCase.java
@@ -8,7 +8,7 @@ import com.pawith.tododomain.service.AssignQueryService;
 import com.pawith.tododomain.service.TodoQueryService;
 import com.pawith.userdomain.entity.User;
 import com.pawith.userdomain.utils.UserUtils;
-import javax.transaction.Transactional;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Assign.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Assign.java
@@ -1,6 +1,7 @@
 package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +9,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import javax.persistence.*;
 
 @Entity
 @Getter

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Category.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Category.java
@@ -1,15 +1,15 @@
 package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
-import java.util.Objects;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+
+import java.util.Objects;
 
 @Entity
 @Getter

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Pet.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Pet.java
@@ -1,6 +1,7 @@
 package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
+import com.pawith.commonmodule.util.DomainFieldUtils;
 import com.pawith.tododomain.entity.vo.PetSpecies;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -48,10 +49,10 @@ public class Pet extends BaseEntity {
 
 
     public void updatePet(String imageUrl, String name, Integer age, String description, String species, String genus) {
-        this.imageUrl = updateIfDifferent(imageUrl, this.imageUrl);
-        this.name = updateIfDifferent(name, this.name);
-        this.age = updateIfDifferent(age, this.age);
-        this.description = updateIfDifferent(description, this.description);
+        this.imageUrl = DomainFieldUtils.updateIfDifferent(imageUrl, this.imageUrl);
+        this.name = DomainFieldUtils.updateIfDifferent(name, this.name);
+        this.age = DomainFieldUtils.updateIfDifferent(age, this.age);
+        this.description = DomainFieldUtils.updateIfDifferent(description, this.description);
         this.petSpecies.updatePetSpecies(genus, species);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Pet.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Pet.java
@@ -2,9 +2,12 @@ package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
 import com.pawith.tododomain.entity.vo.PetSpecies;
-import lombok.*;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
 
 @Entity
 @Getter

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Register.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Register.java
@@ -1,7 +1,7 @@
 package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
-import java.util.Objects;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,8 +9,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import javax.persistence.*;
-import java.util.Arrays;
+import java.util.Objects;
 
 @Entity
 @Getter

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Todo.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Todo.java
@@ -1,24 +1,16 @@
 package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
-import java.time.LocalDate;
-import java.util.Objects;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+
+import java.time.LocalDate;
+import java.util.Objects;
 
 @Entity
 @Getter

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/TodoNotification.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/TodoNotification.java
@@ -1,12 +1,12 @@
 package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
 import java.time.LocalTime;
 
 @Entity

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/TodoTeam.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/TodoTeam.java
@@ -1,6 +1,7 @@
 package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
+import com.pawith.commonmodule.util.DomainFieldUtils;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -32,8 +33,8 @@ public class TodoTeam extends BaseEntity {
     }
 
     public void updateTodoTeam(String teamName, String description, String imageUrl) {
-        this.teamName = updateIfDifferent(teamName, this.teamName);
-        this.description = updateIfDifferent(description, this.description);
-        this.imageUrl = updateIfDifferent(imageUrl, this.imageUrl);
+        this.teamName = DomainFieldUtils.updateIfDifferent(teamName, this.teamName);
+        this.description = DomainFieldUtils.updateIfDifferent(description, this.description);
+        this.imageUrl = DomainFieldUtils.updateIfDifferent(imageUrl, this.imageUrl);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/TodoTeam.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/TodoTeam.java
@@ -1,9 +1,12 @@
 package com.pawith.tododomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
-import lombok.*;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
 
 @Entity
 @Getter

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/vo/PetSpecies.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/vo/PetSpecies.java
@@ -1,10 +1,10 @@
 package com.pawith.tododomain.entity.vo;
 
+import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Embeddable;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/vo/PetSpecies.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/vo/PetSpecies.java
@@ -1,5 +1,6 @@
 package com.pawith.tododomain.entity.vo;
 
+import com.pawith.commonmodule.util.DomainFieldUtils;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,11 +22,7 @@ public class PetSpecies {
     }
 
     public void updatePetSpecies(String genus, String species) {
-        this.genus = updateIfDifferent(genus, this.genus);
-        this.species = updateIfDifferent(species, this.species);
-    }
-
-    public <T> T updateIfDifferent(T newValue, T currentValue) {
-        return Objects.equals(newValue, currentValue) ? currentValue : Objects.requireNonNullElse(newValue, currentValue);
+        this.genus = DomainFieldUtils.updateIfDifferent(genus, this.genus);
+        this.species = DomainFieldUtils.updateIfDifferent(species, this.species);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoNotificationRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoNotificationRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.Duration;
+
 public interface TodoNotificationRepository extends JpaRepository<TodoNotification, Long> {
 
     @Query("select c.todoTeam.id as todoTeamId ,r.userId as userId, c.name as categoryName, t.description as todoDescription, tn.notificationTime as notificationTime " +
@@ -15,7 +17,7 @@ public interface TodoNotificationRepository extends JpaRepository<TodoNotificati
         "join fetch Todo t on a.todo = t and t.scheduledDate = date(now()) " +
         "join fetch Category c on t.category = c "+
         "join fetch Register r on a.register = r and r.isRegistered = true "+
-        "where hour(timediff(tn.notificationTime,current_time)) <= :criterionTime " +
-        "and timediff(tn.notificationTime,current_time) > 0")
-    Slice<NotificationDao> findAllWithNotCompletedAssignAndTodayScheduledTodo(Integer criterionTime, Pageable pageable);
+        "where (tn.notificationTime-current_time) <= :criterionTime " +
+        "and timediff(tn.notificationTime, current_time) > 0")
+    Slice<NotificationDao> findAllWithNotCompletedAssignAndTodayScheduledTodo(Duration criterionTime, Pageable pageable);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/PetQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/PetQueryService.java
@@ -3,9 +3,10 @@ package com.pawith.tododomain.service;
 import com.pawith.commonmodule.annotation.DomainService;
 import com.pawith.tododomain.entity.Pet;
 import com.pawith.tododomain.repository.PetRepository;
-import java.util.List;
-import javax.transaction.Transactional;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @DomainService
 @RequiredArgsConstructor

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -4,7 +4,7 @@
 [[가입된-Todo-Team-조회-마이페이지]]
 === 가입된 Todo Team 조회 (마이페이지용)
 
-operation::todo-team-controller-test/get-todo-teams[snippets='http-request,request-parameters,request-headers,http-response,response-fields']
+operation::todo-team-controller-test/get-todo-teams[snippets='http-request,query-parameters,request-headers,http-response,response-fields']
 
 [[가입된-Todo-Team-조회-메인페이지-todo페이지]]
 === 가입된 Todo Team 조회 (메인페이지, todo페이지에서 페밀리 선택 버튼)
@@ -14,7 +14,7 @@ operation::todo-team-controller-test/get-todo-team-name[snippets='http-request,r
 [[Todo-Team-가입]]
 === Todo Team 가입
 
-operation::register-controller-test/post-register[snippets='http-request,request-parameters,request-headers,http-response']
+operation::register-controller-test/post-register[snippets='http-request,query-parameters,request-headers,http-response']
 
 [[Todo-Team-생성]]
 === Todo Team 생성
@@ -49,19 +49,19 @@ operation::todo-team-controller-test/get-todo-team-info[snippets='http-request,p
 [[Todo-Team-정보-수정]]
 === Todo Team 정보 수정
 
-operation::todo-team-controller-test/put-todo-team-info[snippets='http-request,path-parameters,request-headers,request-fields,http-response']
+operation::todo-team-controller-test/put-todo-team-info[snippets='http-request,path-parameters,request-part-todoTeamUpdateInfo-fields,request-headers,http-response']
 [[Todo-API]]
 == Todo API
 
 [[할당-받은-Todo-조회-메인페이지-조회용]]
 === 할당받은 Todo 조회 (메인페이지 조회용)
 
-operation::todo-controller-test/get-todos[snippets='http-request,path-parameters,request-parameters,request-headers,http-response,response-fields']
+operation::todo-controller-test/get-todos[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 
 [[카테고리-하위-Todo-조회]]
 === 카테고리 하위 Todo 조회
 
-operation::todo-controller-test/get-todo-list[snippets='http-request,path-parameters,request-headers,request-parameters,http-response,response-fields']
+operation::todo-controller-test/get-todo-list[snippets='http-request,path-parameters,request-headers,query-parameters,http-response,response-fields']
 
 [[Todo-달성률]]
 === Todo 달성률 조회
@@ -106,19 +106,19 @@ operation::todo-controller-test/delete-todo[snippets='http-request,path-paramete
 [[Todo-알림-설정]]
 === Todo 알림 설정
 
-operation::todo-controller-test/post-notification[snippets='http-request,request-headers,path-parameters,request-parameters,http-response']
+operation::todo-controller-test/post-notification[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
 [[Todo-알림-설정-조회]]
 
 [[TodoTeam-탈퇴시-담당했던-Todo-조회]]
 === TodoTeam 탈퇴시 담당했던 Todo 조회
 
-operation::todo-controller-test/get-withdraw-todo-list[snippets='http-request,path-parameters,request-headers,request-parameters,http-response,response-fields']
+operation::todo-controller-test/get-withdraw-todo-list[snippets='http-request,path-parameters,request-headers,query-parameters,http-response,response-fields']
 
 [[서비스-탈퇴시-담당했던-Todo-조회]]
 === 서비스 탈퇴시 담당했던 Todo 조회
 
-operation::todo-controller-test/get-all-withdraw-todo-list[snippets='http-request,request-headers,request-parameters,http-response,response-fields']
+operation::todo-controller-test/get-all-withdraw-todo-list[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
 
 [[TodoTeam-탈퇴시-담당했던-Todo-개수-조회]]
 === TodoTeam 탈퇴시 담당했던 Todo 개수 조회
@@ -162,12 +162,12 @@ operation::category-controller-test/put-category-name[snippets='http-request,pat
 [[Register-API]]
 == Register API
 
-[[Todo-Team에-가입된-사용자-조회]]
+[[Todo-Team에-가입된-사용자-조회-todo-생성]]
 === Todo Team에 가입된 사용자 조회 (todo 생성할 때 사용)
 
 operation::register-controller-test/get-registers[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 
-[[Todo-Team에-가입된-사용자-조회]]
+[[Todo-Team에-가입된-사용자-조회-관리자]]
 === Todo Team에 가입된 사용자 조회 (관리자 페이지에서 회원 정보 조회할 때 사용)
 
 operation::register-controller-test/get-manage-registers[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
@@ -180,7 +180,7 @@ operation::register-controller-test/put-authority[snippets='http-request,path-pa
 [[Todo-Teamd에-가입된-사용자-검색]]
 === Todo Team에 가입된 사용자 검색
 
-operation::register-controller-test/get-register-by-nickname[snippets='http-request,path-parameters,request-headers,request-parameters,http-response,response-fields']
+operation::register-controller-test/get-register-by-nickname[snippets='http-request,path-parameters,request-headers,query-parameters,http-response,response-fields']
 
 [[Todo-Team-탈퇴]]
 === Todo Team 탈퇴
@@ -207,7 +207,7 @@ operation::pet-controller-test/get-todo-team-pets[snippets='http-request,path-pa
 [[PET-생성]]
 === PET 생성
 
-operation::pet-controller-test/post-todo-team-pet[snippets='http-request,request-fields,request-headers,http-response']
+operation::pet-controller-test/post-todo-team-pet[snippets='http-request,path-parameters,request-part-petCreateInfo-fields,request-headers,http-response']
 
 [[PET-삭제]]
 === PET 삭제
@@ -217,4 +217,4 @@ operation::pet-controller-test/delete-todo-team-pet[snippets='http-request,path-
 [[PET-정보-수정]]
 === PET 정보 수정
 
-operation::pet-controller-test/put-todo-team-pet[snippets='http-request,path-parameters,request-headers,request-fields,http-response']
+operation::pet-controller-test/put-todo-team-pet[snippets='http-request,path-parameters,request-headers,request-part-petUpdateInfo-fields,http-response']

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/CategoryControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/CategoryControllerTest.java
@@ -180,7 +180,7 @@ public class CategoryControllerTest extends BaseRestDocsTest {
     public void getCategoryListForManage() throws Exception {
         // given
         final Long testTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
-        final List<CategoryManageInfoResponse> categoryListResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(CategoryManageInfoResponse.class, 2);
+        final List<CategoryManageInfoResponse> categoryListResponses = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(CategoryManageInfoResponse.class, 2);
         given(categoryGetUseCase.getManageCategoryList(testTeamId)).willReturn(ListResponse.from(categoryListResponses));
         MockHttpServletRequestBuilder request = get(CATEGORY_REQUEST_URL + "/{teamId}/category/manage", testTeamId)
                 .header("Authorization", "Bearer accessToken");

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/CategoryControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/CategoryControllerTest.java
@@ -57,7 +57,7 @@ public class CategoryControllerTest extends BaseRestDocsTest {
     public void getCategoryList() throws Exception {
         // given
         final Long testTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
-        final List<CategoryInfoResponse> categoryListResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(CategoryInfoResponse.class, 2);
+        final List<CategoryInfoResponse> categoryListResponses = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(CategoryInfoResponse.class, 2);
         given(categoryGetUseCase.getCategoryList(testTeamId)).willReturn(ListResponse.from(categoryListResponses));
         MockHttpServletRequestBuilder request = get(CATEGORY_REQUEST_URL + "/{teamId}/category", testTeamId)
                 .header("Authorization", "Bearer accessToken");

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/PetControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/PetControllerTest.java
@@ -1,20 +1,5 @@
 package com.pawith.todopresentation;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
@@ -23,7 +8,6 @@ import com.pawith.todoapplication.service.PetChangeUseCase;
 import com.pawith.todoapplication.service.PetCreateUseCase;
 import com.pawith.todoapplication.service.PetDeleteUseCase;
 import com.pawith.todoapplication.service.PetGetUseCase;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +17,17 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Slf4j
 @WebMvcTest(PetController.class)
@@ -61,7 +56,7 @@ public class PetControllerTest extends BaseRestDocsTest {
     void getTodoTeamPets() throws Exception {
         // given
         final Long testTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
-        final List<PetInfoResponse> petInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(PetInfoResponse.class, 2);
+        final List<PetInfoResponse> petInfoResponses = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(PetInfoResponse.class, 2);
         given(petGetUseCase.getTodoTeamPets(testTeamId)).willReturn(ListResponse.from(petInfoResponses));
         MockHttpServletRequestBuilder request = get(PET_REQUEST_URL + "/{todoTeamId}/pets", testTeamId)
                 .header("Authorization", "Bearer accessToken");

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -209,9 +209,9 @@ class RegisterControllerTest extends BaseRestDocsTest {
     @DisplayName("닉네임으로 Register를 검색하는 테스트")
     void getRegisterByNickname() throws Exception {
         //given
-        final Long todoTeamId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
+        final Long todoTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
         final String nickname = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(String.class);
-        final List<RegisterSearchInfoResponse> registerSearchInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(RegisterSearchInfoResponse.class, 2);
+        final List<RegisterSearchInfoResponse> registerSearchInfoResponses = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(RegisterSearchInfoResponse.class, 2);
         given(registersGetUseCase.searchRegisterByNickname(todoTeamId, nickname)).willReturn(ListResponse.from(registerSearchInfoResponses));
         MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}/registers/search", todoTeamId)
             .queryParam("nickname", nickname)

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -82,7 +82,7 @@ class RegisterControllerTest extends BaseRestDocsTest {
                 requestHeaders(
                     headerWithName("Authorization").description("access 토큰")
                 ),
-                requestParameters(
+                queryParameters(
                     parameterWithName("todoTeamCode").description("TodoTeam의 코드")
                 )
             ));
@@ -227,7 +227,7 @@ class RegisterControllerTest extends BaseRestDocsTest {
                 pathParameters(
                     parameterWithName("todoTeamId").description("TodoTeam의 Id")
                 ),
-                requestParameters(
+                queryParameters(
                     parameterWithName("nickname").description("검색할 Register의 nickname")
                 ),
                 responseFields(

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -393,6 +393,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
                         responseFields(
                                 fieldWithPath("content[].categoryName").description("투두 항목 카테고리 이름"),
                                 fieldWithPath("content[].task").description("투두 항목 이름"),
+                                fieldWithPath("content[].categoryId").description("투두 카테고리 id"),
                                 fieldWithPath("page").description("요청 페이지"),
                                 fieldWithPath("size").description("요청 사이즈"),
                                 fieldWithPath("hasNext").description("다음 데이터 존재 여부")

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -109,7 +109,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
                         pathParameters(
                                 parameterWithName("todoTeamId").description("TodoTeam의 Id")
                         ),
-                        requestParameters(
+                        queryParameters(
                                 parameterWithName("page").description("요청 페이지"),
                                 parameterWithName("size").description("요청 사이즈")
                         ),
@@ -178,7 +178,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
                         pathParameters(
                                 parameterWithName("categoryId").description("Category의 Id")
                         ),
-                        requestParameters(
+                        queryParameters(
                                 parameterWithName("moveDate").description("달력에서 이동하는 날짜(LocalDate)")
                         ),
                         responseFields(
@@ -360,7 +360,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
                 pathParameters(
                     parameterWithName("todoId").description("투두 항목 Id")
                 ),
-                requestParameters(
+                queryParameters(
                     parameterWithName("notificationTime").description("알림 시간")
                 )
             ));
@@ -393,7 +393,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
                         pathParameters(
                                 parameterWithName("todoTeamId").description("투두 팀 Id")
                         ),
-                        requestParameters(
+                        queryParameters(
                                 parameterWithName("page").description("요청 페이지"),
                                 parameterWithName("size").description("요청 사이즈")
                         ),
@@ -430,7 +430,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
                         requestHeaders(
                                 headerWithName("Authorization").description("access 토큰")
                         ),
-                        requestParameters(
+                        queryParameters(
                                 parameterWithName("page").description("요청 페이지"),
                                 parameterWithName("size").description("요청 사이즈")
                         ),

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -1,16 +1,10 @@
 package com.pawith.todopresentation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawith.commonmodule.BaseRestDocsTest;
 import com.pawith.commonmodule.response.ListResponse;
 import com.pawith.commonmodule.response.SliceResponse;
 import com.pawith.commonmodule.utils.FixtureMonkeyUtils;
-import com.pawith.todoapplication.dto.response.TodoTeamInfoDetailResponse;
-import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
-import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
-import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
-import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
-import com.pawith.todoapplication.dto.response.WithdrawTodoTeamResponse;
+import com.pawith.todoapplication.dto.response.*;
 import com.pawith.todoapplication.service.TodoTeamChangeUseCase;
 import com.pawith.todoapplication.service.TodoTeamCreateUseCase;
 import com.pawith.todoapplication.service.TodoTeamGetUseCase;
@@ -22,15 +16,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import java.util.List;
-import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -38,13 +29,9 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.request;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.web.servlet.function.RequestPredicates.accept;
 
 @Slf4j
 @WebMvcTest(TodoTeamController.class)

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -257,7 +257,8 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
     @DisplayName("서비스 탈퇴 시 가입한 팀 조회 API 테스트")
     void getWithdrawTodoTeam() throws Exception {
         //given
-        final List<WithdrawTodoTeamResponse> withdrawTodoTeamResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(WithdrawTodoTeamResponse.class, 5);
+        final List<WithdrawTodoTeamResponse> withdrawTodoTeamResponses =
+            FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(WithdrawTodoTeamResponse.class, 5);
         given(todoTeamGetUseCase.getWithdrawTodoTeam()).willReturn(ListResponse.from(withdrawTodoTeamResponses));
         MockHttpServletRequestBuilder request = get(TODO_TEAM_REQUEST_URL + "/withdraw")
                 .header("Authorization", "Bearer accessToken");
@@ -281,7 +282,7 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
     void getTodoTeamInfo() throws Exception {
         //given
         final Long todoTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
-        final TodoTeamInfoDetailResponse todoTeamInfoDetailResponse = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
+        final TodoTeamInfoDetailResponse todoTeamInfoDetailResponse = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
             .giveMeOne(TodoTeamInfoDetailResponse.class);
         given(todoTeamGetUseCase.getTodoTeamInfo(todoTeamId)).willReturn(todoTeamInfoDetailResponse);
         MockHttpServletRequestBuilder request = get(TODO_TEAM_REQUEST_URL+"/{todoTeamId}", todoTeamId)

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -93,7 +93,7 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
                 requestHeaders(
                     headerWithName("Authorization").description("access 토큰")
                 ),
-                requestParameters(
+                queryParameters(
                     parameterWithName("page").description("요청 페이지"),
                     parameterWithName("size").description("요청 사이즈")
                 ),

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/entity/PathHistory.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/entity/PathHistory.java
@@ -1,9 +1,9 @@
 package com.pawith.userdomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
+import jakarta.persistence.*;
 import lombok.*;
 
-import javax.persistence.*;
 
 @Entity
 @Getter

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/entity/User.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/entity/User.java
@@ -2,11 +2,14 @@ package com.pawith.userdomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
 import com.pawith.commonmodule.enums.Provider;
-import lombok.*;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import javax.persistence.*;
 import java.util.Objects;
 
 @Entity

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/entity/UserAuthority.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/entity/UserAuthority.java
@@ -1,9 +1,12 @@
 package com.pawith.userdomain.entity;
 
 import com.pawith.commonmodule.domain.BaseEntity;
-import lombok.*;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
 
 @Entity
 @Getter

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Module Dependencies
 
-<img src=".github/docs/components-Modules.png" width="600">
+<img src=".github/docs/components-Modules.png">
 
 
 ## 성능 개선

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id "java-test-fixtures"
-    id 'org.springframework.boot' version '2.7.13'
+    id 'org.springframework.boot' version '3.1.5'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
@@ -9,7 +9,7 @@ plugins {
 allprojects {
     group = 'com.pawith'
     version = '0.0.1'
-    sourceCompatibility = '11'
+    sourceCompatibility = '17'
 
     repositories {
         mavenCentral()

--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -33,10 +33,25 @@ subprojects {
         // retryable
         implementation 'org.springframework.retry:spring-retry'
 
+        // modulith
+        implementation 'org.springframework.modulith:spring-modulith-starter-core'
+        runtimeOnly 'org.springframework.modulith:spring-modulith-runtime'
+        testImplementation 'org.springframework.modulith:spring-modulith-starter-test'
+
         //AWS S3
         implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
         // redis
 //        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    }
+
+    dependencyManagement {
+        imports {
+            mavenBom 'org.springframework.modulith:spring-modulith-bom:1.0.2'
+        }
+    }
+
+    tasks.named('bootBuildImage') {
+        builder = 'paketobuildpacks/builder-jammy-base:latest'
     }
 
 }


### PR DESCRIPTION
## 작업사항
- 자바 11 -> 17로 변경 및 SpringBoot 버전 3으로 변경
- 엔티티 필드 변경시 검증용 유틸 클래스 추가
- CI/CD, Dockerfile 자바 버전 수정
- SecurityConfig 버전 수정에 따른 설정 변경

## 변경로직
- javax 모두 jakarta 패키지로 수정했습니다.

## 참고자료
- 내용을 적어주세요.



