### PR TITLE
Pet 178 feat : 투두 팀 재가입 로직 추가 

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamNameResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamNameResponse.java
@@ -1,11 +1,14 @@
 package com.pawith.todoapplication.dto.response;
 
+import com.pawith.tododomain.entity.Authority;
 import lombok.*;
 
 @Getter
+@Builder
 @ToString
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class TodoTeamNameResponse {
     private Long teamId;
     private String teamName;
+    private Authority authority;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoTeamMapper.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoTeamMapper.java
@@ -2,6 +2,7 @@ package com.pawith.todoapplication.mapper;
 
 import com.pawith.todoapplication.dto.request.TodoTeamCreateRequest;
 import com.pawith.todoapplication.dto.response.TodoTeamInfoDetailResponse;
+import com.pawith.todoapplication.dto.response.TodoTeamNameResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamRandomCodeResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamSearchInfoResponse;
 import com.pawith.todoapplication.dto.response.TodoTeamInfoResponse;
@@ -23,6 +24,14 @@ public class TodoTeamMapper {
             .teamName(request.getTeamName())
             .imageUrl(imageUrl)
             .description(request.getDescription())
+            .build();
+    }
+
+    public static TodoTeamNameResponse mapToTodoTeamNameResponse(final TodoTeam todoTeam, final Register register) {
+        return TodoTeamNameResponse.builder()
+            .teamId(todoTeam.getId())
+            .teamName(todoTeam.getTeamName())
+            .authority(register.getAuthority())
             .build();
     }
 

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoTeamGetUseCase.java
@@ -52,12 +52,12 @@ public class TodoTeamGetUseCase {
 
     public ListResponse<TodoTeamNameResponse> getTodoTeamName() {
         final User requestUser = userUtils.getAccessUser();
-        return ListResponse.from(
-                todoTeamQueryService.findAllTodoTeamByUserId(requestUser.getId())
+        final List<TodoTeamNameResponse> todoTeamNameResponses =
+            registerQueryService.findRegisterListByUserId(requestUser.getId())
                 .stream()
-                .map(todoTeam -> new TodoTeamNameResponse(todoTeam.getId(), todoTeam.getTeamName()))
-                .collect(Collectors.toList())
-        );
+                .map(register -> TodoTeamMapper.mapToTodoTeamNameResponse(register.getTodoTeam(), register))
+                .collect(Collectors.toList());
+        return ListResponse.from(todoTeamNameResponses);
     }
 
     public TodoTeamSearchInfoResponse searchTodoTeamByCode(final String code) {

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
@@ -48,4 +48,8 @@ public interface RegisterRepository extends JpaRepository<Register, Long> {
     @Modifying
     @Query("update Register r set r.isDeleted=true , r.isRegistered=false where r.id in (:registerIds)")
     void deleteByRegisterIds(List<Long> registerIds);
+
+    @Modifying
+    @Query("update Register r set r.isRegistered = true where r.todoTeam.id = :todoTeamId and r.userId = :userId")
+    void changeIsRegisteredWhenRegisterAlreadyExist(Long todoTeamId, Long userId);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
@@ -28,6 +28,10 @@ public class RegisterQueryService {
         return registerRepository.findAllByUserId(userId, pageable);
     }
 
+    public List<Register> findRegisterListByUserId(Long userId) {
+        return registerRepository.findAllByUserId(userId);
+    }
+
     public Register findRegisterByTodoTeamIdAndUserId(Long todoTeamId, Long userId) {
         return findRegister(() -> registerRepository.findByTodoTeamIdAndUserId(todoTeamId, userId));
     }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterSaveService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterSaveService.java
@@ -17,6 +17,10 @@ public class RegisterSaveService {
     private final RegisterRepository registerRepository;
 
     public void saveRegisterAboutMember(TodoTeam todoTeam, Long userId) {
+        if(registerRepository.existsByTodoTeamIdAndUserIdAndIsRegistered(todoTeam.getId(), userId, false)){
+            registerRepository.changeIsRegisteredWhenRegisterAlreadyExist(todoTeam.getId(), userId);
+            return;
+        }
         saveRegisterEntity(todoTeam, userId, Authority.MEMBER);
     }
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -213,7 +213,8 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
                 ),
                 responseFields(
                     fieldWithPath("content[].teamId").description("TodoTeam의 Id"),
-                    fieldWithPath("content[].teamName").description("TodoTeam의 이름")
+                    fieldWithPath("content[].teamName").description("TodoTeam의 이름"),
+                    fieldWithPath("content[].authority").description("TodoTeam의 권한")
                 )
             ));
     }


### PR DESCRIPTION
## 작업사항
- 투두 팀 재가입 시 is_registered 값 수정하는 로직 추가
- 투두 화면, 메인 화면에서 사용하는 가입한 TodoTeam 조회 API 응답값에 권한 추가

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



