### PR TITLE
Pet 182 refactor : 카테고리 하위 투두 조회 로직 수정, 펫 정보 업데이트 로직 수정 

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoResponse.java
@@ -16,4 +16,5 @@ public class CategorySubTodoResponse {
     private String task;
     private CompletionStatus completionStatus;
     private List<AssignUserInfoResponse> assignNames;
+    private Boolean isAssigned;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoGetUseCase.java
@@ -68,7 +68,7 @@ public class TodoGetUseCase {
         for (Todo todo : groupByTodo.keySet()) {
             List<Assign> assigns = new ArrayList<>(groupByTodo.get(todo));
             assigns.sort(Comparator.comparing(assign ->
-                    Objects.equals(userMap.get(registerMap.get(assign.getRegister().getId()).getUserId()).getId(), user.getId()) ? 0 : 1
+                    Objects.equals(assign.getRegister().getUserId(), user.getId()) ? 0 : 1
             ));
             ArrayList<AssignUserInfoResponse> assignUserInfoResponses = new ArrayList<>();
             for (Assign assign : assigns) {

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Pet.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/entity/Pet.java
@@ -48,7 +48,7 @@ public class Pet extends BaseEntity {
     }
 
 
-    public void updatePet(String imageUrl, String name, Integer age, String description, String species, String genus) {
+    public void updatePet(String imageUrl, String name, Integer age, String genus, String species, String description) {
         this.imageUrl = DomainFieldUtils.updateIfDifferent(imageUrl, this.imageUrl);
         this.name = DomainFieldUtils.updateIfDifferent(name, this.name);
         this.age = DomainFieldUtils.updateIfDifferent(age, this.age);

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/AssignRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/AssignRepository.java
@@ -16,7 +16,7 @@ public interface AssignRepository extends JpaRepository<Assign, Long> {
         "from Assign a " +
         "join fetch a.register " +
         "join fetch a.todo t " +
-        "where t.category.id=:categoryId and t.scheduledDate=:scheduledDate")
+        "where t.category.id=:categoryId and t.scheduledDate=:scheduledDate order by t.completionStatus desc")
     List<Assign> findAllByCategoryIdAndScheduledDate(Long categoryId, LocalDate scheduledDate);
 
 

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/CategoryRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/CategoryRepository.java
@@ -7,8 +7,9 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    @Query("select c from Category c where c.todoTeam.id = :todoTeamId and c.categoryStatus = 'ON'")
+    @Query("select c from Category c where c.todoTeam.id = :todoTeamId and c.categoryStatus = 'ON' order by c.createdAt desc")
     List<Category> findAllByTodoTeamIdAndCategoryStatus(Long todoTeamId);
 
+    @Query("select c from Category c where c.todoTeam.id = :todoTeamId order by c.createdAt desc")
     List<Category> findAllByTodoTeamId(Long todoTeamId);
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -181,7 +181,8 @@ public class TodoControllerTest extends BaseRestDocsTest {
                                 fieldWithPath("content[].completionStatus").description("투두 항목 상태(완료, 미완료)"),
                                 fieldWithPath("content[].assignNames[].assigneeId").description("할당받은 사용자의 ID"),
                                 fieldWithPath("content[].assignNames[].assigneeName").description("할당받은 사용자의 이름"),
-                                fieldWithPath("content[].assignNames[].completionStatus").description("할당받은 사용자의 완료 상태(완료, 미완료)")
+                                fieldWithPath("content[].assignNames[].completionStatus").description("할당받은 사용자의 완료 상태(완료, 미완료)"),
+                                fieldWithPath("content[].isAssigned").description("사용자가 할당받은 투두인지 여부")
                         )
                 ));
     }


### PR DESCRIPTION
## 작업사항
- 카테고리 하위 투두 조회 시 사용자가 가장 앞으로 오게 정렬, 해당 투두에 사용자가 할당되어있는지 여부 값 추가 
- 카테고리 하위 투두 조회 시 완료한 투두는 아래로 내려가게 수정 
- 펫 정보 수정 관련 메서드 파라미터 순서 수정

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



