### PR TITLE
Pet 186 refactor : 카테고리 하위 todo 조회 최적화 및 알림 여부 필드 추가

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/CategorySubTodoResponse.java
@@ -1,15 +1,12 @@
 package com.pawith.todoapplication.dto.response;
 
 import com.pawith.tododomain.entity.CompletionStatus;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
-@ToString
+@Builder
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class CategorySubTodoResponse {
     private Long todoId;
@@ -17,4 +14,5 @@ public class CategorySubTodoResponse {
     private CompletionStatus completionStatus;
     private List<AssignUserInfoResponse> assignNames;
     private Boolean isAssigned;
+    private TodoNotificationInfoResponse notificationInfo;
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoNotificationInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoNotificationInfoResponse.java
@@ -1,0 +1,15 @@
+package com.pawith.todoapplication.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@AllArgsConstructor
+@Getter
+public class TodoNotificationInfoResponse {
+    private Boolean isNotification;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private LocalTime notificationTime;
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoMapper.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoMapper.java
@@ -1,10 +1,15 @@
 package com.pawith.todoapplication.mapper;
 
 import com.pawith.todoapplication.dto.request.TodoCreateRequest;
+import com.pawith.todoapplication.dto.response.AssignUserInfoResponse;
+import com.pawith.todoapplication.dto.response.CategorySubTodoResponse;
+import com.pawith.todoapplication.dto.response.TodoNotificationInfoResponse;
 import com.pawith.tododomain.entity.Category;
 import com.pawith.tododomain.entity.Todo;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TodoMapper {
@@ -14,6 +19,20 @@ public class TodoMapper {
             .category(category)
             .description(request.getDescription())
             .scheduledDate(request.getScheduledDate())
+            .build();
+    }
+
+    public static CategorySubTodoResponse mapToCategorySubTodoResponse(Todo todo,
+                                                                       List<AssignUserInfoResponse> assignsList,
+                                                                       Boolean isAssigned,
+                                                                       TodoNotificationInfoResponse todoNotificationInfoResponse){
+        return CategorySubTodoResponse.builder()
+            .todoId(todo.getId())
+            .task(todo.getDescription())
+            .completionStatus(todo.getCompletionStatus())
+            .assignNames(assignsList)
+            .isAssigned(isAssigned)
+            .notificationInfo(todoNotificationInfoResponse)
             .build();
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoWithdrawGetUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoWithdrawGetUseCase.java
@@ -1,0 +1,52 @@
+package com.pawith.todoapplication.service;
+
+import com.pawith.commonmodule.annotation.ApplicationService;
+import com.pawith.commonmodule.response.SliceResponse;
+import com.pawith.todoapplication.dto.response.TodoCountResponse;
+import com.pawith.todoapplication.dto.response.WithdrawAllTodoResponse;
+import com.pawith.todoapplication.dto.response.WithdrawTodoResponse;
+import com.pawith.tododomain.service.TodoQueryService;
+import com.pawith.userdomain.entity.User;
+import com.pawith.userdomain.utils.UserUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional
+public class TodoWithdrawGetUseCase {
+
+    private final UserUtils userUtils;
+    private final TodoQueryService todoQueryService;
+
+
+    public SliceResponse<WithdrawTodoResponse> getWithdrawTeamTodoList(Long todoTeamId, final Pageable pageable) {
+        final User user = userUtils.getAccessUser();
+        final Slice<WithdrawTodoResponse> withdrawTodoResponses =
+            todoQueryService.findAllTodoListByTodoTeamId(user.getId(), todoTeamId, pageable)
+                .map(todo -> new WithdrawTodoResponse(todo.getCategory().getId(), todo.getCategory().getName(), todo.getDescription()));
+        return SliceResponse.from(withdrawTodoResponses);
+    }
+
+    public SliceResponse<WithdrawAllTodoResponse> getWithdrawTodoList(Pageable pageable) {
+        final User user = userUtils.getAccessUser();
+        final Slice<WithdrawAllTodoResponse> withdrawAllTodoResponses =
+            todoQueryService.findAllTodoListByUserId(user.getId(), pageable)
+                .map(todo -> new WithdrawAllTodoResponse(todo.getCategory().getTodoTeam().getImageUrl(), todo.getCategory().getName(), todo.getDescription()));
+        return SliceResponse.from(withdrawAllTodoResponses);
+    }
+
+    public TodoCountResponse getWithdrawTeamTodoCount(Long todoTeamId) {
+        final User user = userUtils.getAccessUser();
+        final Integer todoCount = todoQueryService.countTodoByTodoTeamId(user.getId(), todoTeamId);
+        return new TodoCountResponse(todoCount);
+    }
+
+    public TodoCountResponse getWithdrawTodoCount() {
+        final User user = userUtils.getAccessUser();
+        final Integer todoCount = todoQueryService.countTodoByUserId(user.getId());
+        return new TodoCountResponse(todoCount);
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoGetUseCaseTest.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/test/java/com/pawith/todoapplication/service/TodoGetUseCaseTest.java
@@ -1,10 +1,7 @@
 package com.pawith.todoapplication.service;
 
 import com.pawith.commonmodule.UnitTestConfig;
-import com.pawith.tododomain.service.AssignQueryService;
-import com.pawith.tododomain.service.CategoryQueryService;
-import com.pawith.tododomain.service.RegisterQueryService;
-import com.pawith.tododomain.service.TodoQueryService;
+import com.pawith.tododomain.service.*;
 import com.pawith.userdomain.service.UserQueryService;
 import com.pawith.userdomain.utils.UserUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,12 +24,14 @@ class TodoGetUseCaseTest {
     private RegisterQueryService registerQueryService;
     @Mock
     private AssignQueryService assignQueryService;
+    @Mock
+    private TodoNotificationQueryService todoNotificationQueryService;
 
     private TodoGetUseCase todoGetUseCase;
 
     @BeforeEach
     void init(){
-        todoGetUseCase = new TodoGetUseCase(userUtils, todoQueryService, userQueryService, registerQueryService, assignQueryService);
+        todoGetUseCase = new TodoGetUseCase(userUtils, todoQueryService, userQueryService, registerQueryService, assignQueryService, todoNotificationQueryService);
     }
 
 //    @Test

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoNotificationRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoNotificationRepository.java
@@ -25,7 +25,7 @@ public interface TodoNotificationRepository extends JpaRepository<TodoNotificati
     @Query(value = """
         select tn
         from TodoNotification tn
-            join fetch Assign a on tn.assign = a and a.completionStatus='INCOMPLETE'
+            join Assign a on tn.assign = a and a.completionStatus='INCOMPLETE'
             join Register r on a.register = r and r.isRegistered = true and r.userId = :userId
         where a.todo.id in :todoId
         """)

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoNotificationRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/TodoNotificationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.Duration;
+import java.util.List;
 
 public interface TodoNotificationRepository extends JpaRepository<TodoNotification, Long> {
 
@@ -20,4 +21,13 @@ public interface TodoNotificationRepository extends JpaRepository<TodoNotificati
         "where (tn.notificationTime-current_time) <= :criterionTime " +
         "and timediff(tn.notificationTime, current_time) > 0")
     Slice<NotificationDao> findAllWithNotCompletedAssignAndTodayScheduledTodo(Duration criterionTime, Pageable pageable);
+
+    @Query(value = """
+        select tn
+        from TodoNotification tn
+            join fetch Assign a on tn.assign = a and a.completionStatus='INCOMPLETE'
+            join Register r on a.register = r and r.isRegistered = true and r.userId = :userId
+        where a.todo.id in :todoId
+        """)
+    List<TodoNotification> findAllByTodoIdWithIncompleteAssign(List<Long> todoId, Long userId);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/TodoNotificationQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/TodoNotificationQueryService.java
@@ -1,0 +1,21 @@
+package com.pawith.tododomain.service;
+
+import com.pawith.commonmodule.annotation.DomainService;
+import com.pawith.tododomain.entity.TodoNotification;
+import com.pawith.tododomain.repository.TodoNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@DomainService
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TodoNotificationQueryService {
+
+    private final TodoNotificationRepository todoNotificationRepository;
+
+    public List<TodoNotification> findAllByTodoIdsWithIncompleteAssign(List<Long> todoIds, Long userId) {
+        return todoNotificationRepository.findAllByTodoIdWithIncompleteAssign(todoIds, userId);
+    }
+}

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/TodoController.java
@@ -28,6 +28,7 @@ public class TodoController {
     private final AssignChangeUseCase assignChangeUseCase;
     private final TodoDeleteUseCase todoDeleteUseCase;
     private final TodoNotificationCreateUseCase todoNotificationCreateUseCase;
+    private final TodoWithdrawGetUseCase todoWithdrawGetUseCase;
 
     @GetMapping("/{todoTeamId}/todos/progress")
     public TodoProgressResponse getTodoProgress(@PathVariable Long todoTeamId) {
@@ -87,22 +88,22 @@ public class TodoController {
 
     @GetMapping("/{todoTeamId}/todos/withdraw")
     public SliceResponse<WithdrawTodoResponse> getWithdrawTeamTodoList(@PathVariable Long todoTeamId, Pageable pageable){
-        return todoGetUseCase.getWithdrawTeamTodoList(todoTeamId, pageable);
+        return todoWithdrawGetUseCase.getWithdrawTeamTodoList(todoTeamId, pageable);
     }
 
     @GetMapping("/todos/withdraw")
     public SliceResponse<WithdrawAllTodoResponse> getWithdrawTodoList(Pageable pageable){
-        return todoGetUseCase.getWithdrawTodoList(pageable);
+        return todoWithdrawGetUseCase.getWithdrawTodoList(pageable);
     }
 
     @GetMapping("/{todoTeamId}/todos/withdraw/count")
     public TodoCountResponse getTodoCount(@PathVariable Long todoTeamId){
-        return todoGetUseCase.getWithdrawTeamTodoCount(todoTeamId);
+        return todoWithdrawGetUseCase.getWithdrawTeamTodoCount(todoTeamId);
     }
 
     @GetMapping("/todos/withdraw/count")
     public TodoCountResponse getTodoCount(){
-        return todoGetUseCase.getWithdrawTodoCount();
+        return todoWithdrawGetUseCase.getWithdrawTodoCount();
     }
 
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoControllerTest.java
@@ -52,6 +52,8 @@ public class TodoControllerTest extends BaseRestDocsTest {
     private TodoDeleteUseCase todoDeleteUseCase;
     @MockBean
     private TodoNotificationCreateUseCase todoNotificationCreateUseCase;
+    @MockBean
+    private TodoWithdrawGetUseCase todoWithdrawGetUseCase;
 
     private static final String TODO_REQUEST_URL = "/teams";
 
@@ -149,11 +151,11 @@ public class TodoControllerTest extends BaseRestDocsTest {
         final Long testCategoryId = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(Long.class);
         final LocalDate testMoveDate = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(LocalDate.class);
         final List<AssignUserInfoResponse> assignUserInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(AssignUserInfoResponse.class, 2);
+        final TodoNotificationInfoResponse todoNotificationInfoResponse = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeBuilder(TodoNotificationInfoResponse.class)
+            .set("isNotification", true)
+            .sample();
         final List<CategorySubTodoResponse> categorySubTodoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
             .giveMeBuilder(CategorySubTodoResponse.class)
-            .set("todoId", Arbitraries.longs().greaterOrEqual(1L))
-            .set("task", Arbitraries.strings().withCharRange('a', 'z').ofMinLength(5).ofMaxLength(10))
-            .set("status", FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMeBuilder("COMPLETE"))
             .set("assignNames", assignUserInfoResponses)
             .sampleList(2);
 
@@ -182,7 +184,9 @@ public class TodoControllerTest extends BaseRestDocsTest {
                                 fieldWithPath("content[].assignNames[].assigneeId").description("할당받은 사용자의 ID"),
                                 fieldWithPath("content[].assignNames[].assigneeName").description("할당받은 사용자의 이름"),
                                 fieldWithPath("content[].assignNames[].completionStatus").description("할당받은 사용자의 완료 상태(완료, 미완료)"),
-                                fieldWithPath("content[].isAssigned").description("사용자가 할당받은 투두인지 여부")
+                                fieldWithPath("content[].isAssigned").description("사용자가 할당받은 투두인지 여부"),
+                                fieldWithPath("content[].notificationInfo.isNotification").description("투두 알림 여부(true, false)"),
+                                fieldWithPath("content[].notificationInfo.notificationTime").description("투두 알림 시간(알림이 없을 경우 안보냄)")
                         )
                 ));
     }
@@ -372,7 +376,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
                 .sampleList(pageRequest.getPageSize());
         final SliceImpl<WithdrawTodoResponse> slice = new SliceImpl(withdrawTodoResponses, pageRequest, true);
 
-        given(todoGetUseCase.getWithdrawTeamTodoList(any(), any())).willReturn(SliceResponse.from(slice));
+        given(todoWithdrawGetUseCase.getWithdrawTeamTodoList(any(), any())).willReturn(SliceResponse.from(slice));
         MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/{todoTeamId}/todos/withdraw", testTeamId)
                 .queryParam("page", String.valueOf(pageRequest.getPageNumber()))
                 .queryParam("size", String.valueOf(pageRequest.getPageSize()))
@@ -413,7 +417,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
                 .sampleList(pageRequest.getPageSize());
         final SliceImpl<WithdrawAllTodoResponse> slice = new SliceImpl(withdrawAllTodoResponses, pageRequest, true);
 
-        given(todoGetUseCase.getWithdrawTodoList(any())).willReturn(SliceResponse.from(slice));
+        given(todoWithdrawGetUseCase.getWithdrawTodoList(any())).willReturn(SliceResponse.from(slice));
         MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/todos/withdraw")
                 .queryParam("page", String.valueOf(pageRequest.getPageNumber()))
                 .queryParam("size", String.valueOf(pageRequest.getPageSize()))
@@ -447,7 +451,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
         //given
         final Long testTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
         final TodoCountResponse todoCountResponse = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(TodoCountResponse.class);
-        given(todoGetUseCase.getWithdrawTeamTodoCount(any())).willReturn(todoCountResponse);
+        given(todoWithdrawGetUseCase.getWithdrawTeamTodoCount(any())).willReturn(todoCountResponse);
         MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/{todoTeamId}/todos/withdraw/count", testTeamId)
                 .header("Authorization", "Bearer accessToken");
         //when
@@ -472,7 +476,7 @@ public class TodoControllerTest extends BaseRestDocsTest {
     void getAllWithdrawTodoCount() throws Exception {
         //given
         final TodoCountResponse todoCountResponse = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(TodoCountResponse.class);
-        given(todoGetUseCase.getWithdrawTodoCount()).willReturn(todoCountResponse);
+        given(todoWithdrawGetUseCase.getWithdrawTodoCount()).willReturn(todoCountResponse);
         MockHttpServletRequestBuilder request = get(TODO_REQUEST_URL + "/todos/withdraw/count")
                 .header("Authorization", "Bearer accessToken");
         //when


### PR DESCRIPTION
## 작업사항
- 카테고리 하위 todo 조회시 발생하는 쿼리 최적화 진행
- 카테고리 하위 todo 조회시 알림 설정 여부(접속 사용자 기준) 추가
- 카테고리 하위 todo dto 변환 mapper 메소드 추가
- 패밀리 탈퇴시 사용할 조회 메소드 TodoWithdrawGetUseCase 분리

## 변경로직
- 카테고리 하위 todo 조회할때 fetch join으로 todo, register 같이 조회하기에 register 추가 쿼리 제거
- 접속 사용자가 할당된 투두에서 이름 정렬하는 로직 통합하여 불필요한 반복문 제거
- 

## 참고자료
- 내용을 적어주세요.



