### PR TITLE
PET-189 refactor : 쿼리 수정, 탈퇴 검증 로직 수정 

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/UnregisterUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/UnregisterUseCase.java
@@ -20,7 +20,12 @@ public class UnregisterUseCase {
     public void unregisterTodoTeam(final Long todoTeamId) {
         final User user = userUtils.getAccessUser();
         final Register register = registerQueryService.findRegisterByTodoTeamIdAndUserId(todoTeamId, user.getId());
-        registerValidateService.validatePresidentRegisterDeletable(register);
         register.unregister();
+    }
+
+    public void validateRegisterDeletable(final Long todoTeamId) {
+        final User user = userUtils.getAccessUser();
+        final Register register = registerQueryService.findRegisterByTodoTeamIdAndUserId(todoTeamId, user.getId());
+        registerValidateService.validatePresidentRegisterDeletable(register);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
@@ -28,7 +28,7 @@ public interface RegisterRepository extends JpaRepository<Register, Long> {
     @Query("select r from Register r join Category c on c.id = :categoryId where c.todoTeam.id= r.todoTeam.id")
     List<Register> findAllByCategoryId(Long categoryId);
 
-    @Query("select r from Register r join fetch r.todoTeam where r.userId = :userId and r.isRegistered = true")
+    @Query("select r from Register r join fetch r.todoTeam where r.userId = :userId and r.isRegistered = true order by r.id desc")
     List<Register> findAllByUserIdWithTodoTeamFetch(Long userId);
 
     List<Register> findAllByUserId(Long userId);

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterRepository.java
@@ -43,9 +43,6 @@ public interface RegisterRepository extends JpaRepository<Register, Long> {
     @Query("select count(r) from Register r where r.todoTeam.id = :todoTeamId and r.authority = :authority and r.isRegistered = true")
     Integer countByTodoTeamIdAndAuthority(Long todoTeamId, Authority authority);
 
-    @Query("select count(r) from Register r where r.authority=:authority and r.todoTeam.id in :todoTeamIds and r.isRegistered = true")
-    List<Integer> countAllByTodoTeamIdsInAndAuthority(List<Long> todoTeamIds, Authority authority);
-
     Boolean existsByTodoTeamIdAndUserIdAndIsRegistered(Long todoTeamId, Long userId, boolean isRegistered);
 
     @Modifying

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -196,6 +196,11 @@ operation::register-controller-test/get-register-term[snippets='http-request,pat
 === Todo 팀 가입자 내보내기
 
 operation::register-controller-test/unregister-register[snippets='http-request,path-parameters,request-headers,http-response']
+
+[[Todo-팀-탈퇴-검증]]
+=== Todo 팀 탈퇴 검증
+
+operation::register-controller-test/validate-register-deletable[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 [[PET-API]]
 == PET API
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
@@ -28,6 +28,11 @@ public class RegisterController {
         unregisterUseCase.unregisterTodoTeam(todoTeamId);
     }
 
+    @PostMapping("/{todoTeamId}/registers/validate")
+    public void validateRegisterDeletable(@PathVariable Long todoTeamId) {
+        unregisterUseCase.validateRegisterDeletable(todoTeamId);
+    }
+
     @PostMapping("/registers")
     public void postRegister(@RequestParam String todoTeamCode) {
         todoTeamRegisterUseCase.registerTodoTeam(todoTeamCode);

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -50,42 +50,43 @@ class RegisterControllerTest extends BaseRestDocsTest {
     void unregisterTodoTeam() throws Exception {
         // given
         final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
-        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.delete(REGISTER_REQUEST_URL + "/{todoTeamId}/registers", todoTeamId)
-            .header("Authorization", "Bearer accessToken");
+        MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.delete(
+                        REGISTER_REQUEST_URL + "/{todoTeamId}/registers", todoTeamId)
+                .header("Authorization", "Bearer accessToken");
         // when
         ResultActions result = mvc.perform(request);
         // then
         result.andExpect(status().isOk())
-            .andDo(resultHandler.document(
-                requestHeaders(
-                    headerWithName("Authorization").description("access 토큰")
-                ),
-                pathParameters(
-                    parameterWithName("todoTeamId").description("삭제할 TodoTeam의 Id")
-                )
-            ));
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("todoTeamId").description("삭제할 TodoTeam의 Id")
+                        )
+                ));
     }
 
     @Test
     @DisplayName("TodoTeamCode로 TodoTeam을 등록하는 테스트")
-    void postRegister() throws Exception{
+    void postRegister() throws Exception {
         //given
         final String todoTeamCode = UUID.randomUUID().toString().split("-")[0];
-        MockHttpServletRequestBuilder request = post(REGISTER_REQUEST_URL+"/registers")
-            .queryParam("todoTeamCode", todoTeamCode)
-            .header("Authorization", "Bearer accessToken");
+        MockHttpServletRequestBuilder request = post(REGISTER_REQUEST_URL + "/registers")
+                .queryParam("todoTeamCode", todoTeamCode)
+                .header("Authorization", "Bearer accessToken");
         //when
         ResultActions result = mvc.perform(request);
         //then
         result.andExpect(status().isOk())
-            .andDo(resultHandler.document(
-                requestHeaders(
-                    headerWithName("Authorization").description("access 토큰")
-                ),
-                queryParameters(
-                    parameterWithName("todoTeamCode").description("TodoTeam의 코드")
-                )
-            ));
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        queryParameters(
+                                parameterWithName("todoTeamCode").description("TodoTeam의 코드")
+                        )
+                ));
     }
 
     @Test
@@ -93,26 +94,27 @@ class RegisterControllerTest extends BaseRestDocsTest {
     void getRegisters() throws Exception {
         //given
         final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
-        final List<RegisterInfoResponse> registerInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(RegisterInfoResponse.class, 10);
+        final List<RegisterInfoResponse> registerInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
+                .giveMe(RegisterInfoResponse.class, 10);
         given(registersGetUseCase.getRegisters(todoTeamId)).willReturn(ListResponse.from(registerInfoResponses));
-        MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}/registers",todoTeamId)
-            .header("Authorization", "Bearer accessToken");
+        MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}/registers", todoTeamId)
+                .header("Authorization", "Bearer accessToken");
         //when
         ResultActions result = mvc.perform(request);
         //then
         result.andExpect(status().isOk())
-            .andDo(resultHandler.document(
-                requestHeaders(
-                    headerWithName("Authorization").description("access 토큰")
-                ),
-                pathParameters(
-                    parameterWithName("todoTeamId").description("조회하는 TodoTeamId")
-                ),
-                responseFields(
-                    fieldWithPath("content[].registerId").description("TodoTeam에 등록된 사용자 registerId"),
-                    fieldWithPath("content[].registerName").description("TodoTeam에 등록된 사용자 이메일")
-                )
-            ));
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("todoTeamId").description("조회하는 TodoTeamId")
+                        ),
+                        responseFields(
+                                fieldWithPath("content[].registerId").description("TodoTeam에 등록된 사용자 registerId"),
+                                fieldWithPath("content[].registerName").description("TodoTeam에 등록된 사용자 이메일")
+                        )
+                ));
 
     }
 
@@ -122,9 +124,11 @@ class RegisterControllerTest extends BaseRestDocsTest {
     void getManageRegisters() throws Exception {
         //given
         final Long todoTeamId = FixtureMonkey.create().giveMeOne(Long.class);
-        final List<RegisterManageInfoResponse> registerManageInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMe(RegisterManageInfoResponse.class, 10);
-        given(registersGetUseCase.getManageRegisters(todoTeamId)).willReturn(ListResponse.from(registerManageInfoResponses));
-        MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}/registers/manage",todoTeamId)
+        final List<RegisterManageInfoResponse> registerManageInfoResponses = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
+                .giveMe(RegisterManageInfoResponse.class, 10);
+        given(registersGetUseCase.getManageRegisters(todoTeamId)).willReturn(
+                ListResponse.from(registerManageInfoResponses));
+        MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}/registers/manage", todoTeamId)
                 .header("Authorization", "Bearer accessToken");
         //when
         ResultActions result = mvc.perform(request);
@@ -154,27 +158,29 @@ class RegisterControllerTest extends BaseRestDocsTest {
         //given
         final Long registerId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
         final Long todoTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
-        final AuthorityChangeRequest authorityChangeRequest = FixtureMonkeyUtils.getConstructBasedFixtureMonkey().giveMeOne(AuthorityChangeRequest.class);
-        MockHttpServletRequestBuilder request = put(REGISTER_REQUEST_URL + "/{todoTeamId}/registers/{registerId}", todoTeamId, registerId)
-            .contentType("application/json")
-            .header("Authorization", "Bearer accessToken")
-            .content(objectMapper.writeValueAsString(authorityChangeRequest));
+        final AuthorityChangeRequest authorityChangeRequest = FixtureMonkeyUtils.getConstructBasedFixtureMonkey()
+                .giveMeOne(AuthorityChangeRequest.class);
+        MockHttpServletRequestBuilder request = put(REGISTER_REQUEST_URL + "/{todoTeamId}/registers/{registerId}",
+                todoTeamId, registerId)
+                .contentType("application/json")
+                .header("Authorization", "Bearer accessToken")
+                .content(objectMapper.writeValueAsString(authorityChangeRequest));
         //when
         ResultActions result = mvc.perform(request);
         //then
         result.andExpect(status().isOk())
-            .andDo(resultHandler.document(
-                requestHeaders(
-                    headerWithName("Authorization").description("access 토큰")
-                ),
-                pathParameters(
-                    parameterWithName("todoTeamId").description("변경할 TodoTeam의 Id"),
-                    parameterWithName("registerId").description("변경할 register의 Id")
-                ),
-                requestFields(
-                    fieldWithPath("authority").description("변경할 권한")
-                )
-            ));
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("todoTeamId").description("변경할 TodoTeam의 Id"),
+                                parameterWithName("registerId").description("변경할 register의 Id")
+                        ),
+                        requestFields(
+                                fieldWithPath("authority").description("변경할 권한")
+                        )
+                ));
     }
 
 
@@ -187,22 +193,22 @@ class RegisterControllerTest extends BaseRestDocsTest {
         final RegisterTermResponse registerTermResponse = new RegisterTermResponse(registerTerm);
         given(registersGetUseCase.getRegisterTerm(todoTeamId)).willReturn(registerTermResponse);
         MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}/registers/term", todoTeamId)
-            .header("Authorization", "Bearer accessToken");
+                .header("Authorization", "Bearer accessToken");
         //when
         ResultActions result = mvc.perform(request);
         //then
         result.andExpect(status().isOk())
-            .andDo(resultHandler.document(
-                requestHeaders(
-                    headerWithName("Authorization").description("access 토큰")
-                ),
-                pathParameters(
-                    parameterWithName("todoTeamId").description("TodoTeam의 Id")
-                ),
-                responseFields(
-                    fieldWithPath("registerTerm").description("팀 가입한 기간")
-                )
-            ));
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("todoTeamId").description("TodoTeam의 Id")
+                        ),
+                        responseFields(
+                                fieldWithPath("registerTerm").description("팀 가입한 기간")
+                        )
+                ));
     }
 
     @Test
@@ -211,33 +217,35 @@ class RegisterControllerTest extends BaseRestDocsTest {
         //given
         final Long todoTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
         final String nickname = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(String.class);
-        final List<RegisterSearchInfoResponse> registerSearchInfoResponses = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey().giveMe(RegisterSearchInfoResponse.class, 2);
-        given(registersGetUseCase.searchRegisterByNickname(todoTeamId, nickname)).willReturn(ListResponse.from(registerSearchInfoResponses));
+        final List<RegisterSearchInfoResponse> registerSearchInfoResponses = FixtureMonkeyUtils.getReflectionbasedFixtureMonkey()
+                .giveMe(RegisterSearchInfoResponse.class, 2);
+        given(registersGetUseCase.searchRegisterByNickname(todoTeamId, nickname)).willReturn(
+                ListResponse.from(registerSearchInfoResponses));
         MockHttpServletRequestBuilder request = get(REGISTER_REQUEST_URL + "/{todoTeamId}/registers/search", todoTeamId)
-            .queryParam("nickname", nickname)
-            .header("Authorization", "Bearer accessToken");
+                .queryParam("nickname", nickname)
+                .header("Authorization", "Bearer accessToken");
         //when
         ResultActions result = mvc.perform(request);
         //then
         result.andExpect(status().isOk())
-            .andDo(resultHandler.document(
-                requestHeaders(
-                    headerWithName("Authorization").description("access 토큰")
-                ),
-                pathParameters(
-                    parameterWithName("todoTeamId").description("TodoTeam의 Id")
-                ),
-                queryParameters(
-                    parameterWithName("nickname").description("검색할 Register의 nickname")
-                ),
-                responseFields(
-                    fieldWithPath("content[].registerId").description("Register의 Id"),
-                    fieldWithPath("content[].authority").description("Register의 권한"),
-                    fieldWithPath("content[].registerName").description("Register의 이름"),
-                    fieldWithPath("content[].registerEmail").description("Register의 이메일"),
-                    fieldWithPath("content[].profileImage").description("Register의 프로필 이미지")
-                )
-            ));
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("todoTeamId").description("TodoTeam의 Id")
+                        ),
+                        queryParameters(
+                                parameterWithName("nickname").description("검색할 Register의 nickname")
+                        ),
+                        responseFields(
+                                fieldWithPath("content[].registerId").description("Register의 Id"),
+                                fieldWithPath("content[].authority").description("Register의 권한"),
+                                fieldWithPath("content[].registerName").description("Register의 이름"),
+                                fieldWithPath("content[].registerEmail").description("Register의 이메일"),
+                                fieldWithPath("content[].profileImage").description("Register의 프로필 이미지")
+                        )
+                ));
     }
 
     @Test
@@ -246,18 +254,39 @@ class RegisterControllerTest extends BaseRestDocsTest {
         //given
         final Long registerId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
         MockHttpServletRequestBuilder request = put(REGISTER_REQUEST_URL + "/registers/{registerId}", registerId)
-            .header("Authorization", "Bearer accessToken");
+                .header("Authorization", "Bearer accessToken");
         //when
         ResultActions result = mvc.perform(request);
         //then
         result.andExpect(status().isOk())
-            .andDo(resultHandler.document(
-                requestHeaders(
-                    headerWithName("Authorization").description("access 토큰")
-                ),
-                pathParameters(
-                    parameterWithName("registerId").description("내보낼 Register의 Id")
-                )
-            ));
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("registerId").description("내보낼 Register의 Id")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("TodoTeam 탈퇴 가능 여부 검증 API 테스트")
+    void validateRegisterDeletable() throws Exception {
+        //given
+        final Long todoTeamId = FixtureMonkeyUtils.getJavaTypeBasedFixtureMonkey().giveMeOne(Long.class);
+        MockHttpServletRequestBuilder request = post(REGISTER_REQUEST_URL + "/{todoTeamId}/registers/validate", todoTeamId)
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("todoTeamId").description("검증할 TodoTeam의 Id")
+                        )
+                ));
     }
 }

--- a/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/repository/UserRepository.java
+++ b/Domain-Module/User-Module/User-Domain/src/main/java/com/pawith/userdomain/repository/UserRepository.java
@@ -14,7 +14,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u from User u where u.id in :ids")
     List<User> findAllByIds(List<Long> ids);
 
-    @Query("select u from User u where u.nickname = :nickname and u.id in :ids")
+    @Query("select u from User u where u.nickname like %:nickname% and u.id in :ids")
     List<User> findAllByNicknameAndIds(String nickname, List<Long> ids);
 
 }


### PR DESCRIPTION
## 작업사항
- TodoTeam 조회(메인페이지, 투두화면)  정렬 최신순으로 수정
- 닉네임으로 사용자 검색 단어 하나만 입력해도 찾을 수 있게 수정
- TodoTeam 탈퇴 검증 API 분리, 테스트 코드 작성, 명세 반영 
- 서비스 탈퇴 검증 로직 수정 

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



