### PR TITLE
Pet 194 refactor : 팀 코드로 팀 조회 API 응답값 수정, 서비스 탈퇴 검증 로직 API로 분리 

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamSearchInfoResponse.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/dto/response/TodoTeamSearchInfoResponse.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TodoTeamSearchInfoResponse {
     private final String code;
+    private final Long teamId;
     private final String teamName;
     private final String presidentName;
     private final Integer registerCount;

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/UserAccountDeleteOnTodoHandler.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/UserAccountDeleteOnTodoHandler.java
@@ -28,7 +28,6 @@ public class UserAccountDeleteOnTodoHandler {
     @EventListener
     public void deleteUserInfo(UserAccountDeleteEvent userAccountDeleteEvent) {
         final List<Register> registers = registerQueryService.findAllRegistersByUserId(userAccountDeleteEvent.getUserId());
-        registerValidateService.validateRegisterDeletable(registers);
         final List<Long> registerIds = registers.stream()
             .map(Register::getId)
             .collect(Collectors.toList());

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoTeamMapper.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/mapper/TodoTeamMapper.java
@@ -49,6 +49,7 @@ public class TodoTeamMapper {
     public static TodoTeamSearchInfoResponse mapToTodoTeamSearchInfoResponse(final TodoTeam todoTeam, final User user, final Integer registerCount) {
         return TodoTeamSearchInfoResponse.builder()
             .teamName(todoTeam.getTeamName())
+            .teamId(todoTeam.getId())
             .code(todoTeam.getTeamCode())
             .description(todoTeam.getDescription())
             .teamImageUrl(todoTeam.getImageUrl())

--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/UnregisterUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/UnregisterUseCase.java
@@ -6,6 +6,7 @@ import com.pawith.tododomain.service.RegisterQueryService;
 import com.pawith.tododomain.service.RegisterValidateService;
 import com.pawith.userdomain.entity.User;
 import com.pawith.userdomain.utils.UserUtils;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,5 +28,11 @@ public class UnregisterUseCase {
         final User user = userUtils.getAccessUser();
         final Register register = registerQueryService.findRegisterByTodoTeamIdAndUserId(todoTeamId, user.getId());
         registerValidateService.validatePresidentRegisterDeletable(register);
+    }
+
+    public void validateRegistersDeletable() {
+        final User user = userUtils.getAccessUser();
+        final List<Register> registers = registerQueryService.findAllRegistersByUserId(user.getId());
+        registerValidateService.validateRegisterDeletable(registers);
     }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/docs/asciidoc/Todo-API.adoc
@@ -206,6 +206,11 @@ operation::register-controller-test/unregister-register[snippets='http-request,p
 === Todo 팀 탈퇴 검증
 
 operation::register-controller-test/validate-register-deletable[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
+
+[[서비스-탈퇴-검증]]
+=== 서비스 탈퇴 검증
+
+operation::register-controller-test/validate-registers-deletable[snippets='http-request,request-headers,http-response']
 [[PET-API]]
 == PET API
 

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/main/java/com/pawith/todopresentation/RegisterController.java
@@ -28,9 +28,20 @@ public class RegisterController {
         unregisterUseCase.unregisterTodoTeam(todoTeamId);
     }
 
+    /**
+     * 팀 탈퇴 시 사용하는 검증 API
+     */
     @PostMapping("/{todoTeamId}/registers/validate")
     public void validateRegisterDeletable(@PathVariable Long todoTeamId) {
         unregisterUseCase.validateRegisterDeletable(todoTeamId);
+    }
+
+    /**
+     * 서비스 탈퇴 시 사용하는 검증 API
+     */
+    @PostMapping("/registers/validate")
+    public void validateRegistersDeletable() {
+        unregisterUseCase.validateRegistersDeletable();
     }
 
     @PostMapping("/registers")

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/RegisterControllerTest.java
@@ -289,4 +289,21 @@ class RegisterControllerTest extends BaseRestDocsTest {
                         )
                 ));
     }
+
+    @Test
+    @DisplayName("서비스 탈퇴 가능 여부 검증 API 테스트")
+    void validateRegistersDeletable() throws Exception {
+        //given
+        MockHttpServletRequestBuilder request = post(REGISTER_REQUEST_URL + "/registers/validate")
+                .header("Authorization", "Bearer accessToken");
+        //when
+        ResultActions result = mvc.perform(request);
+        //then
+        result.andExpect(status().isOk())
+                .andDo(resultHandler.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("access 토큰")
+                        )
+                ));
+    }
 }

--- a/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
+++ b/Domain-Module/Todo-Module/Todo-Presentation/src/test/java/com/pawith/todopresentation/TodoTeamControllerTest.java
@@ -245,6 +245,7 @@ class TodoTeamControllerTest extends BaseRestDocsTest {
                 ),
                 responseFields(
                     fieldWithPath("code").description("TodoTeam의 코드"),
+                    fieldWithPath("teamId").description("TodoTeam의 Id"),
                     fieldWithPath("teamName").description("TodoTeam의 이름"),
                     fieldWithPath("presidentName").description("TodoTeam의 대표자 이름"),
                     fieldWithPath("registerCount").description("TodoTeam의 가입자 수"),


### PR DESCRIPTION
## 작업사항
- 팀 코드로 팀 조회 API 응답값에 TeamId 추가, 명세 반영
- 서비스 탈퇴 검증 로직 새로운 API로 분리, 해당 API 테스트 코드 작성, 명세 반영 

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



