### PR TITLE
Pet 206 fix : 알림 설정 시간과 비교시 스케줄러 시작 시간과 비교하도록 수정

### DIFF
--- a/.github/workflows/CD-prod.yml
+++ b/.github/workflows/CD-prod.yml
@@ -95,7 +95,7 @@ jobs:
           target: "/home/ubuntu"
           strip_components: 2
 
-      - name: deploy docker-compose-dev push
+      - name: deploy docker-compose-prod push
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.PROD_HOST }}


### PR DESCRIPTION
## 작업사항
- 알림 설정 시간과 비교시 스케줄러 시작 시간과 비교하도록 수정
- CD 플로우 이름 수정

## 변경로직
- 시간 비교 메소드 제거했습니다.

## 참고자료
- 내용을 적어주세요.



