### PR TITLE
PET-230 fix : 알림 데이터 추출시 트랜잭션 범위 조정

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/TodoNotificationHandler.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/handler/TodoNotificationHandler.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.Duration;
@@ -19,7 +18,6 @@ import java.time.LocalTime;
 
 @Slf4j
 @Component
-@Transactional
 @RequiredArgsConstructor
 public class TodoNotificationHandler {
     private static final Integer BATCH_SIZE = 100;


### PR DESCRIPTION
## 작업사항
- 알림 데이터 추출시 트랜잭션 범위 조정, 커넥션 점유 시간이 너무 많아서 특정 요청에 대해 응답시간이 느려져 트랜잭션 애노테이션 제거했습니다.

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



