### PR TITLE
Pet 275 hotfix : Register 조회시 todoTeamId가 없으면 categoryId로 조회하도록 수정

### DIFF
--- a/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoCreateUseCase.java
+++ b/Domain-Module/Todo-Module/Todo-Application/src/main/java/com/pawith/todoapplication/service/TodoCreateUseCase.java
@@ -31,7 +31,8 @@ public class TodoCreateUseCase {
 
     public void createTodo(TodoCreateRequest request) {
         final User accessUser = userUtils.getAccessUser();
-        final Long accessUserRegisterId = registerQueryService.findRegisterByTodoTeamIdAndUserId(request.getTodoTeamId(), accessUser.getId()).getId();
+        final Long accessUserRegisterId =
+            registerQueryService.findRegisterByNullableTodoTeamIdAndUserIdAndCategoryId(request.getTodoTeamId(), accessUser.getId(), request.getCategoryId()).getId();
         final Category category = categoryQueryService.findCategoryByCategoryId(request.getCategoryId());
         final Todo todo = TodoMapper.mapToTodo(request, category, accessUserRegisterId);
         todoSaveService.saveTodoEntity(todo);

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterQueryRepository.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/repository/RegisterQueryRepository.java
@@ -16,4 +16,6 @@ public interface RegisterQueryRepository {
     Optional<Register> findLatestRegisterByUserIdQuery(Long userId);
     void deleteByRegisterIdsQuery(List<Long> registerIds);
     <T extends IncompleteTodoCountInfoDao> List<T> findAllIncompleteTodoCountInfoQuery(Pageable pageable);
+
+    Optional<Register> findByUserIdAndCategoryId(Long userId, Long categoryId);
 }

--- a/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
+++ b/Domain-Module/Todo-Module/Todo-Domain/src/main/java/com/pawith/tododomain/service/RegisterQueryService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -33,6 +34,13 @@ public class RegisterQueryService {
     }
 
     public Register findRegisterByTodoTeamIdAndUserId(Long todoTeamId, Long userId) {
+        return findRegister(() -> registerRepository.findByTodoTeamIdAndUserId(todoTeamId, userId));
+    }
+
+    public Register findRegisterByNullableTodoTeamIdAndUserIdAndCategoryId(Long todoTeamId, Long userId, Long categoryId) {
+        if(Objects.isNull(todoTeamId)){
+            return findRegister(() -> registerRepository.findByUserIdAndCategoryId(userId, categoryId));
+        }
         return findRegister(() -> registerRepository.findByTodoTeamIdAndUserId(todoTeamId, userId));
     }
 

--- a/Domain-Module/Todo-Module/Todo-Infrastructure/src/main/java/com/pawith/todoinfrastructure/repository/RegisterRepositoryImpl.java
+++ b/Domain-Module/Todo-Module/Todo-Infrastructure/src/main/java/com/pawith/todoinfrastructure/repository/RegisterRepositoryImpl.java
@@ -89,6 +89,19 @@ public class RegisterRepositoryImpl implements RegisterQueryRepository {
     }
 
     @Override
+    public Optional<Register> findByUserIdAndCategoryId(Long userId, Long categoryId) {
+        QRegister qRegister = QRegister.register;
+        QTodoTeam qTodoTeam = qRegister.todoTeam;
+        QCategory qCategory = QCategory.category;
+        return Optional.ofNullable(queryFactory.select(qRegister)
+            .from(qRegister)
+            .join(qTodoTeam)
+            .join(qCategory).on(qCategory.todoTeam.eq(qTodoTeam))
+            .where(qRegister.userId.eq(userId).and(qCategory.id.eq(categoryId)))
+            .fetchOne());
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public List<IncompleteTodoCountInfoDaoImpl> findAllIncompleteTodoCountInfoQuery(Pageable pageable) {
         final QRegister qRegister = QRegister.register;

--- a/Event/src/main/java/com/pawith/event/christmas/ChristmasEventListener.java
+++ b/Event/src/main/java/com/pawith/event/christmas/ChristmasEventListener.java
@@ -16,12 +16,16 @@ public class ChristmasEventListener {
 
     @EventListener
     public void handleEventCreateNewTodoTeam(ChristmasEvent.ChristmasEventCreateNewTodoTeam event) {
-        final TodoTeam todoTeam = todoTeamQueryService.findTodoTeamById(event.todoTeamId());
-        christmasEventService.publishEvent(todoTeam);
+        if(christmasEventService.isEventDay()){
+            final TodoTeam todoTeam = todoTeamQueryService.findTodoTeamById(event.todoTeamId());
+            christmasEventService.publishEvent(todoTeam);
+        }
     }
 
     @EventListener
     public void handleEventCreateNewRegister(ChristmasEvent.ChristmasEventCreateNewRegister event) {
-        christmasEventService.addNewRegisterAtChristmasEventTodo(event.todoTeamId(), event.userId());
+        if(christmasEventService.isEventDay()){
+            christmasEventService.addNewRegisterAtChristmasEventTodo(event.todoTeamId(), event.userId());
+        }
     }
 }

--- a/Event/src/main/java/com/pawith/event/christmas/ChristmasEventService.java
+++ b/Event/src/main/java/com/pawith/event/christmas/ChristmasEventService.java
@@ -83,4 +83,8 @@ public class ChristmasEventService {
             });
     }
 
+    public Boolean isEventDay(){
+        return EVENT_TODO_SCHEDULED_DATE_LIST.contains(LocalDate.now());
+    }
+
 }


### PR DESCRIPTION
## 작업사항
- Register 조회시 todoTeamId가 없으면 categoryId로 조회하도록 수정
- 이벤트 투두는 이벤트 기간이 아니면 생성하지 않도록 수정

## 변경로직
- 내용을 적어주세요.

## 참고자료
- 내용을 적어주세요.



